### PR TITLE
Fixed path-related bugs in Windows build script when cloning universal.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,5 +4,12 @@ copy lib\libcurl.dll bin
 start build.cmd
 cd ..
 
-if not exist ../node_modules mkdir ../node_modules
-if not exist ../node_modules/universal git clone git://github.com/GPII/universal.git
+if not exist ..\node_modules (
+    mkdir ..\node_modules
+)
+
+if not exist ../node_modules/universal (
+    cd ..\node_modules
+    git clone git://github.com/GPII/universal.git
+    cd ..\windows
+)


### PR DESCRIPTION
I've fixed a couple of bugs in the Windows build scripts:
1. I was using Unix-style slashes in a couple of places
2. I was cloning Universal to the wrong location

I've tested these changes on Windows XP with Windows Git installed and they seem to be working great.
