### PR TITLE
Updated implementation to use more basic API RegDeleteKeyW rather than RegDeleteKeyExW which is not supported on XP.

### DIFF
--- a/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
@@ -61,11 +61,18 @@ var advapi32 = new ffi.Library("advapi32", {
     RegSetValueExW: [
         "long", ["pointer", "pointer", "uint32", "uint32", "pointer", "uint32"]
     ],
-    // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724847(v=vs.85).aspx
-    // HKEY, LPCWSTR, REGSAM, DWORD
-    RegDeleteKeyExW: [
-        "long", ["uint32", "pointer", "uint32", "uint32"]
+    // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724845(v=vs.85).aspx
+    // HKEY, LPCWSTR
+    // Similar abuse to RegOpenKeyExW - for convenience, only accepts base keys
+    RegDeleteKeyW: [
+        "long", ["uint32", "pointer"]
     ]
+    // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724847(v=vs.85).aspx
+    // This API is disused since it was introduced only on Windows Server 2003 (XP support required)
+    // HKEY, LPCWSTR, REGSAM, DWORD
+    //RegDeleteKeyExW: [
+    //    "long", ["uint32", "pointer", "uint32", "uint32"]
+    //]
 });
 
 var kernel32 = new ffi.Library("kernel32", {
@@ -288,10 +295,13 @@ windows.writeRegistryKey = function (baseKey, path, subKey, value, type) {
     return togo;
 };
 
+// Note that this function cannot delete keys recursively. RegDeleteKeyExW is not available
+// as a result of requirement for Windows XP level API support. This functionality can be
+// implemented manually on top of this existing API if required.
 windows.deleteRegistryKey = function (baseKey, path) {
     var pathW = windows.toWideChar(path).pointer;
     var base = windows.getBaseKey(baseKey);
-    var code = advapi32.RegDeleteKeyExW(base, pathW, 0, 0);
+    var code = advapi32.RegDeleteKeyW(base, pathW);
     cr(code);
 };
 


### PR DESCRIPTION
Note that this API was only used in the self-test driver and is not currently essential to the operation of the SettingsHandler.
