### PR TITLE
GPII-12: Taskkill.exe cannot kill processes when the user is not administrator...

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -15,3 +15,7 @@ if not exist ..\node_modules\universal (
     npm install
     cd ..\..\windows
 )
+
+cd gpii\node_modules\WindowsUtilities\pkill
+start build.cmd
+cd ..\..\..\..

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,3 +1,4 @@
 del UsbUserListener\src\UsbUserListener.o
 del UsbUserListener\bin\libcurl.dll
 del UsbUserListener\bin\UsbUserListener.exe
+del gpii\node_modules\WindowsUtilities\pkill\bin /q

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -25,6 +25,13 @@ var Struct = require("ref-struct");
 var NULL = ref.NULL;
 
 var os = require("os");
+var path = require("path");
+
+windows.pkill = new ffi.Library(path.join(__dirname, "pkill/bin/pkill.dll"), {
+    "killProcessByName": [
+        "void", ["pointer"]
+    ]
+});
 
 windows.kernel32 = new ffi.Library("kernel32", {
     // http://msdn.microsoft.com/en-us/library/windows/desktop/dd319072(v=vs.85).aspx
@@ -465,5 +472,25 @@ windows.bufferToArray = function (buffer, type) {
     
     return array;
 };
+
+/**
+ * Kills all processes with the given name (case insensitive).
+ *
+ * @param {String} name The name of the process to kill.
+ */
+windows.killProcessByName = function (name) {
+    var nameBuf = new Buffer(Buffer.byteLength(name) + 1); // allocate 1 more byte for the null character
+    nameBuf.write(name, 0);
+    nameBuf.writeInt8(0, nameBuf.length - 1);
+
+    windows.pkill.killProcessByName(nameBuf);
+};
+
+fluid.defaults("gpii.windows.killProcessByName", {
+    gradeNames: "fluid.function",
+    argumentMap: {
+        name: 0
+    }
+});
 
 exports.windows = windows;

--- a/gpii/node_modules/WindowsUtilities/pkill/build.cmd
+++ b/gpii/node_modules/WindowsUtilities/pkill/build.cmd
@@ -1,0 +1,7 @@
+if not exist bin (
+    mkdir bin
+)
+
+g++ -c src/pkill.cpp -o bin/pkill.o
+g++ -shared -o bin/pkill.dll bin/pkill.o -Wl,--out-implib,bin/pkill.a
+del bin\pkill.o

--- a/gpii/node_modules/WindowsUtilities/pkill/src/pkill.cpp
+++ b/gpii/node_modules/WindowsUtilities/pkill/src/pkill.cpp
@@ -1,0 +1,37 @@
+#include "pkill.h"
+#include <windows.h>
+#include <process.h>
+#include <Tlhelp32.h>
+#include <winbase.h>
+
+char tolower(char c) {
+    return c + (c >= 'A' && c <= 'Z') * ('a' - 'A');
+}
+
+int equalsCaseInsensitive(const char* left, const char* rigth) {
+	int i;
+
+	for(i = 0; left[i] && tolower(left[i]) == tolower(rigth[i]); ++i);
+
+	return !(left[i] || rigth[i]);
+}
+
+void killProcessByName(const char *filename) {
+    HANDLE hSnapShot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, NULL);
+    PROCESSENTRY32 pEntry;
+    pEntry.dwSize = sizeof (pEntry);
+    BOOL hRes = Process32First(hSnapShot, &pEntry);
+
+    while (hRes) {
+        if (equalsCaseInsensitive(pEntry.szExeFile, filename)) {
+            HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, 0, (DWORD) pEntry.th32ProcessID);
+            if (hProcess != NULL) {
+                TerminateProcess(hProcess, 9);
+                CloseHandle(hProcess);
+            }
+        }
+        hRes = Process32Next(hSnapShot, &pEntry);
+    }
+
+    CloseHandle(hSnapShot);
+}

--- a/gpii/node_modules/WindowsUtilities/pkill/src/pkill.h
+++ b/gpii/node_modules/WindowsUtilities/pkill/src/pkill.h
@@ -1,0 +1,14 @@
+#ifndef _PKILL_H_
+#define _PKILL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void __declspec(dllexport) killProcessByName(const char *filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _PKILL_H_


### PR DESCRIPTION
http://issues.gpii.net/browse/GPII-12

The pkill dynamic library is referenced in WindowsUtilities and used instead of taskkill.exe for terminating processes by their names.
