### PR TITLE
Various Bugs for Windows Listeners - support NTAG and Provide installer

### DIFF
--- a/listeners/GPII_USBListener/README.md
+++ b/listeners/GPII_USBListener/README.md
@@ -1,4 +1,4 @@
-GPII USB User Listener for Windows
+#GPII USB User Listener for Windows
 
 This folder contains the necessary files for the Windows USB listener (source code and libraries).
 

--- a/listeners/README.md
+++ b/listeners/README.md
@@ -1,16 +1,16 @@
-+ Listeners
+# Listeners
 
 The GPII listeners for windows are currently USB and RFID (NFC). See individual README.md files for details
 The executables can be found in ./bin/{Debug,Release} though the installer is only in Release
 
-+ Building
+# Building
 
-++ In VisualStudio
+## In VisualStudio
 
 Open listener.sln in VS, right click on Solution in the explorer and build.
 Has been tested in VS2013 (12) express
 
-++ On command line with MSBuild
+## On command line with MSBuild
 
 Open a command window and run
 

--- a/listeners/README.md
+++ b/listeners/README.md
@@ -7,7 +7,7 @@ The executables can be found in ./bin/{Debug,Release} though the installer is on
 
 ## In VisualStudio
 
-Open listener.sln in VS, right click on Solution in the explorer and build.
+Open listener.sln in VS, sleect Debug or Release and right click on Solution in the explorer and build.
 Has been tested in VS2013 (12) express
 
 ## On command line with MSBuild
@@ -22,4 +22,5 @@ Open a command window and run
 * Build the Release solution (See above)
 * Note the version number for the installer .exe will be the greater of the 2 listeners versions
 * Checkin the code to GitHub (or make a pull request)
-* Make a GitHub release using a Tag of the form "Listeners_V1.3.0" (using the installer version) 
+* Make a binary GitHub release of the installer using a Tag of the form "Listeners_V1.3.0" (using the installer version)
+* Include the MD5 hash in the release text. Both Cygwin and the Msys shell of GitHub for Windows include md5sum

--- a/listeners/installer/README.md
+++ b/listeners/installer/README.md
@@ -1,3 +1,5 @@
+# Notes
+
 The installer is created using the unicode vesion of Inno Setup and it's preprocessor'
 http://www.jrsoftware.org/isinfo.php
 


### PR DESCRIPTION
* Builds with VS 2012
* Single EXE and no extra DLLs (removed libcurl.dll)
* USB listening now works
* No F11 hotkey to avoid clashes