### PR TITLE
GPII-291: removed windows font-size assertions from the acceptance tests

### DIFF
--- a/tests/AcceptanceTests.js
+++ b/tests/AcceptanceTests.js
@@ -327,25 +327,6 @@ var testDefs = [
         gpiiConfig: gpiiConfig,
         token: "os_gnome",
         settingsHandlers: {
-            "gpii.windows.spiSettingsHandler": {
-                "data": [ {
-                    "settings": {
-                        "CaptionFontHeight": {
-                            "path": "pvParam.lfCaptionFont.lfHeight",
-                            "value": -9
-                        }
-                    },
-                    "options": {
-                        "getAction": "SPI_GETNONCLIENTMETRICS",
-                        "setAction": "SPI_SETNONCLIENTMETRICS",
-                        "uiParam": "struct_size",
-                        "pvParam": {
-                            "type": "struct",
-                            "name": "NONCLIENTMETRICS"
-                        }
-                    }
-                } ]
-            },
             "gpii.windows.registrySettingsHandler": {
                 "data": [{ //magnifier stuff
                     "settings": {


### PR DESCRIPTION
This pull request should be reviewed with: https://github.com/GPII/universal/pull/178

(see: http://issues.gpii.net/browse/GPII-291)
