### PR TITLE
GPII-668: Acceptance test added ensuring that the system doesn't crash on login with empty NP set

### DIFF
--- a/tests/acceptanceTests/AcceptanceTests_other.js
+++ b/tests/acceptanceTests/AcceptanceTests_other.js
@@ -1,0 +1,32 @@
+/*
+
+GPII Acceptance Testing
+
+Copyright 2014 Raising the Floor - International
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://github.com/gpii/universal/LICENSE.txt
+*/
+
+/*global require,process*/
+
+"use strict";
+var fluid = require("universal"),
+    path = require("path"),
+    gpii = fluid.registerNamespace("gpii");
+
+fluid.require("./AcceptanceTests_include", require);
+
+var testDefs = [
+    {
+        name: "Testing that the system doesn't crashes on login with empty NP set",
+        token: "empty",
+        settingsHandlers: {},
+        processes: []
+    }
+];
+
+gpii.acceptanceTesting.windows.runTests("builtIn_config", testDefs);

--- a/tests/acceptanceTests/AcceptanceTests_other.txt
+++ b/tests/acceptanceTests/AcceptanceTests_other.txt
@@ -1,0 +1,11 @@
+AcceptanceTests_other.js
+=======================
+
+Description:
+This will run the acceptance tests that falls out of category and dont have any specific requirements on 3rd party applications.
+
+It uses the following NP sets:
+* empty.json
+
+Requirements:
+* none


### PR DESCRIPTION
Should be reviewed with: https://github.com/GPII/universal/pull/237/files

To do a "before/after" run of the acceptance test by using master and GPII-668 branch, respectively, of kaspermarkus/universal, make sure to add the empty ({}) "empty.json" preferences set exist in the testData/preferences/acceptanceTests folder when running with master, so the fail wont be due to a missing file.
