### PR TITLE
JIRA-1292: Added new top levell gpii folder to the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ than 1.4.  If you need to upgrade npm you can issue the following command:
 
 To build the GPII for Windows using grunt, perform the following:
 
+    mkdir gpii
+    cd gpii
     git clone https://github.com/GPII/windows.git
     cd windows
     npm install --ignore-scripts=true


### PR DESCRIPTION
Otherwise a node-modules is created as peer of windows and that is probably not wanted as will be amongst other project folders
