### PR TITLE
GPII-1307: Binding to updated version of grunt-gpii with fixed implementation of shellImmediate

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",
     "grunt-jsonlint": "1.0.4",
-    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#ec8412064e107febb120f0b7437d403453b40d2d",
+    "grunt-gpii": "1.0.0",
     "shelljs": "0.3.0"
   },
   "licenses": [


### PR DESCRIPTION
@kaspermarkus  - when you merge https://github.com/GPII/grunt-gpii/pull/3 , you can also PUBLISH IT IN NPM as befits our new glorious policy