### PR TITLE
GPII-1814: Fixes CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ will be withdrawn soon. You can operate these as follows:
 
 It is possible to provision a Windows VM for testing purposes. Please ensure you have met [these VM requirements](https://github.com/GPII/qi-development-environments/#requirements) before proceeding. After that you can use the ``vagrant up`` command to create an instance of a [Windows 10 Evaluation VM](https://github.com/idi-ops/packer-windows) which will boot an instance of the Windows 10 VM, pull in the GPII Framework's npm dependencies, and then build it. 
 
-If this is your first time creating this VM a 6.5GB download will take place. The downloaded image will be valid for 90 days after which the Windows installation will no longer be useable. To remove an expired image you can use the ``vagrant box remove "inclusivedesign/windows10-eval"`` command.
+If this is your first time creating this VM an 8 GB download will take place. The downloaded image will be valid for 90 days after which the Windows installation will no longer be useable. To remove an expired image you can use the ``vagrant box remove "inclusivedesign/windows10-eval"`` command.
 
-Once the VM has finished booting up you can open a command prompt window and use the following commands to test the framework:
+Once the VM has finished booting up you will need to type the ``vagrant reload`` command to cause it to restart. This is required so changes made to the Windows VM's ``PATH`` environment variable as part of the provisioning process are available in terminal sessions. This step is a temporary workaround and will be removed in the near future. 
+
+Now you can open a command prompt window and use the following commands to test the framework:
 
 ```
 cd c:\vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,5 +37,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", path: "provisioning/chocolatey-packages.bat"
   config.vm.provision "shell", path: "provisioning/npm-packages.bat"
   config.vm.provision "shell", path: "provisioning/build.bat"
+  config.vm.provision "shell", path: "provisioning/universal.bat"
 
 end

--- a/provisioning/build.bat
+++ b/provisioning/build.bat
@@ -1,10 +1,3 @@
 cd c:\vagrant
 npm install
 
-mkdir c:\node_modules
-cd c:\node_modules
-git clone --depth 1 https://github.com/GPII/universal.git
-cd universal
-npm install
-npm install dedupe-infusion
-node -e "require('dedupe-infusion')()"

--- a/provisioning/build.bat
+++ b/provisioning/build.bat
@@ -1,3 +1,3 @@
 cd c:\vagrant
-npm install --ignore-scripts=true
+npm install
 grunt build

--- a/provisioning/build.bat
+++ b/provisioning/build.bat
@@ -1,3 +1,10 @@
 cd c:\vagrant
 npm install
-grunt build
+
+mkdir c:\node_modules
+cd c:\node_modules
+git clone --depth 1 https://github.com/GPII/universal.git
+cd universal
+npm install
+npm install dedupe-infusion
+node -e "require('dedupe-infusion')()"

--- a/provisioning/chocolatey-packages.bat
+++ b/provisioning/chocolatey-packages.bat
@@ -1,3 +1,4 @@
-choco install nodejs -version 4.4.3 --forcex86 -y
-choco install nodejs.install -version 4.4.3 --forcex86 -y
-setx /M PATH "%PATH%;c:\programdata\chocolatey\lib\nodejs.commandline\tools;c:\users\vagrant\appdata\roaming\npm"
+choco install nodejs.install -version 4.4.3 -y
+choco install python2 -y
+setx /M PATH "%PATH%;C:\Program Files\nodejs;C:\tools\python2"
+call npm config set msvs_version 2015 --global

--- a/provisioning/chocolatey-packages.bat
+++ b/provisioning/chocolatey-packages.bat
@@ -1,4 +1,3 @@
 choco install nodejs.install -version 4.4.3 -y
 choco install python2 -y
 setx /M PATH "%PATH%;C:\Program Files\nodejs;C:\tools\python2"
-call npm config set msvs_version 2015 --global

--- a/provisioning/npm-packages.bat
+++ b/provisioning/npm-packages.bat
@@ -1,2 +1,3 @@
+call npm config set msvs_version 2015 --global
 call npm install grunt-cli -g
 call npm install testem -g

--- a/provisioning/universal.bat
+++ b/provisioning/universal.bat
@@ -1,0 +1,7 @@
+mkdir c:\node_modules
+cd c:\node_modules
+git clone --depth 1 https://github.com/GPII/universal.git
+cd universal
+npm install
+npm install dedupe-infusion
+node -e "require('dedupe-infusion')()"


### PR DESCRIPTION
These changes require an updated Vagrant box used by the GPII CI server:
https://github.com/idi-ops/packer-windows/commit/fe400f04192d9fa1e23547ae82e1f263ff8c441d