### PR TITLE
GPII-1873: Fixing problem of Windows defining the value of default scheme to null for HighContrast method.

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -249,7 +249,7 @@ gpii.windows.spi.setImpl = function (payload) {
 
     gpii.windows.spi.populateResults(payload, true, false, results);
 
-    GPII1873_HighContrastBug("SET", payload, results);
+    gpii.windows.spi.GPII1873_HighContrastBug("SET", payload, results);
 
     // transform results here   oldValue: x   -->   oldValue: { value: x, path: ... }
     fluid.each(results, function (value, setting) {
@@ -271,7 +271,7 @@ gpii.windows.spi.getImpl = function (payload) {
     var results = {};
     gpii.windows.spi.populateResults(payload, false, true, results);
 
-    GPII1873_HighContrastBug("GET", payload, results);
+    gpii.windows.spi.GPII1873_HighContrastBug("GET", payload, results);
 
     return results;
 };
@@ -310,7 +310,7 @@ fluid.defaults("gpii.windows.spiSettingsHandler.updateCursors", {
  *
  * More information at https://issues.gpii.net/browse/GPII-1873
  */
-function GPII1873_HighContrastBug(method, payload, results) {
+gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) {
     if ((payload.options.pvParam.type === "struct") &&
         (payload.options.pvParam.name === "HIGHCONTRAST")) {
         if (payload.settings.HighContrastTheme &&

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -249,6 +249,8 @@ gpii.windows.spi.setImpl = function (payload) {
 
     gpii.windows.spi.populateResults(payload, true, false, results);
 
+    GPII1873_HighContrastBug("SET", payload, results);
+
     // transform results here   oldValue: x   -->   oldValue: { value: x, path: ... }
     fluid.each(results, function (value, setting) {
         results[setting].oldValue = {"value": value.oldValue, "path": payload.settings[setting].path};
@@ -268,6 +270,8 @@ gpii.windows.spi.getImpl = function (payload) {
     gpii.windows.defineStruct(payload);
     var results = {};
     gpii.windows.spi.populateResults(payload, false, true, results);
+
+    GPII1873_HighContrastBug("GET", payload, results);
 
     return results;
 };
@@ -296,6 +300,29 @@ fluid.defaults("gpii.windows.spiSettingsHandler.updateCursors", {
     argumentMap: {}
 });
 
+/**
+ * Fix for GPII-1873.
+ *
+ * This method overrides the output of the system based on the payload information. We
+ * actually know that Windows have a bug that disallow us to reset to the HighContrastTheme
+ * default scheme to null or empty string. That is the reason we are circumventing the
+ * output of this HIGHCONTRAST methods.
+ *
+ * More information at https://issues.gpii.net/browse/GPII-1873
+ */
+function GPII1873_HighContrastBug(method, payload, results) {
+    if ((payload.options.pvParam.type === "struct") &&
+        (payload.options.pvParam.name === "HIGHCONTRAST")) {
+        if (payload.settings.HighContrastTheme.value === "") {
+            console.log("SET Bug #1873 detected. We are forcing the return set to empty string although the system cannot set to it.");
+            if (method === "SET") {
+                results.HighContrastTheme.newValue = "";
+            } else {
+                results.HighContrastTheme.value = "";
+            }
+        }
+    }
+}
 
 if (process.argv[1].indexOf("piSettingsHandler") !== -1 && process.argv.length === 3) {
     var filename = __dirname + "/" + process.argv[2];

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -313,8 +313,9 @@ fluid.defaults("gpii.windows.spiSettingsHandler.updateCursors", {
 function GPII1873_HighContrastBug(method, payload, results) {
     if ((payload.options.pvParam.type === "struct") &&
         (payload.options.pvParam.name === "HIGHCONTRAST")) {
-        if (payload.settings.HighContrastTheme.value === "") {
-            console.log("SET Bug #1873 detected. We are forcing the return set to empty string although the system cannot set to it.");
+        if (payload.settings.HighContrastTheme &&
+            payload.settings.HighContrastTheme.value === "") {
+            console.log("Bug #1873 detected. We are forcing the return set to empty string although the system cannot set to it.");
             if (method === "SET") {
                 results.HighContrastTheme.newValue = "";
             } else {

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -315,7 +315,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
         (payload.options.pvParam.name === "HIGHCONTRAST")) {
         if (payload.settings.HighContrastTheme &&
             payload.settings.HighContrastTheme.value === "") {
-            console.log("Bug #1873 detected. We are forcing the return set to empty string although the system cannot set to it.");
+            fluid.log("Bug #1873 detected. We are forcing the return value to empty string although the system cannot set to it.");
             if (method === "SET") {
                 results.HighContrastTheme.newValue = "";
             } else {

--- a/gpii/node_modules/spiSettingsHandler/test/testHighContrastToEmpty.json
+++ b/gpii/node_modules/spiSettingsHandler/test/testHighContrastToEmpty.json
@@ -1,0 +1,33 @@
+{
+    "options": {
+        "getAction": "SPI_GETHIGHCONTRAST",
+        "setAction": "SPI_SETHIGHCONTRAST",
+        "uiParam": "struct_size",
+        "pvParam": {
+            "type": "struct",
+            "name": "HIGHCONTRAST",
+            "template": {
+                "cbSize": "uint32",
+                "dwFlags": "uint32",
+                "lpszDefaultScheme": "pointer"
+            }
+        }
+    },
+    
+    "settings": {
+        "HighContrastOn": {
+            "value": false,
+            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON"
+        },
+        
+        "HotkeyActive": {
+            "value": true,
+            "path": "pvParam.dwFlags.HCF_HOTKEYACTIVE"
+        },
+        
+        "HighContrastTheme": {
+            "value": "",
+            "path": "pvParam.lpszDefaultScheme"
+        }
+    }
+}

--- a/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
@@ -26,7 +26,7 @@ require("../src/spiSettingsHandler.js");
 
 jqUnit.module("SpiSettingsHandler Module");
 
-var testPayloads = ["testMouseTrails", "testFilterKeys", "testMouse", "testMouseClickLock", "testLogFont", "testNonClientMetrics", "testStickyKeys", "testHighContrast"];
+var testPayloads = ["testMouseTrails", "testFilterKeys", "testMouse", "testMouseClickLock", "testLogFont", "testNonClientMetrics", "testStickyKeys", "testHighContrast", "testHighContrastToEmpty"];
 
 fluid.each(testPayloads, function (name) {
     jqUnit.test("SpiSettingsHandler test - " + name, function () {


### PR DESCRIPTION
GPII-1873: Fixing problem of Windows defining the value of default scheme to null for HighContrast method.

Workaround for the current problem we are having with HighContrast method.