### PR TITLE
GPII-580: Added registration of Infusion ContextAwareness marker 

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ var fluid = require("universal");
 
 fluid.module.register("gpii-windows", __dirname, require);
 
+fluid.contextAware.makeChecks({
+    "gpii.contexts.windows": {
+        value: true
+    }
+});
+
 require("./gpii/node_modules/WindowsUtilities/WindowsUtilities.js");
 require("./gpii/node_modules/processHandling/processHandling.js");
 require("./gpii/node_modules/registrySettingsHandler");


### PR DESCRIPTION
representing Windows platform for use in Journalling component and other contexts

This pull request partners https://github.com/GPII/universal/pull/463 but does not depend on it
