### PR TITLE
GPII-2001: Unit tests get stalled at some point during its execution

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
@@ -20,8 +20,8 @@
 
 var ffi = require("ffi");
 
-// 0 if uiParam is a block of data, otherwise it's a literal value.
-var pvParamPrimitive = process.env.GPII_SPI_PVPARAM_PRIMITIVE;
+// 1 if uiParam is a literal number, otherwise it's a block of data.
+var pvParamPrimitive = process.env.GPII_SPI_PVPARAM_PRIMITIVE === "1";
 var action = process.env.GPII_SPI_ACTION;
 var uiParam = process.env.GPII_SPI_UIPARAM;
 
@@ -31,7 +31,7 @@ if (pvParamPrimitive) {
     pvParam = process.env.GPII_SPI_PVPARAM;
 } else {
     type = "void*";
-    pvParam = new Buffer(process.env.GPII_SPI_PVPARAM);
+    pvParam = new Buffer(process.env.GPII_SPI_PVPARAM, "hex");
 }
 
 var user32 = ffi.Library("user32", {

--- a/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
@@ -40,4 +40,4 @@ var user32 = ffi.Library("user32", {
     ]
 });
 
-return user32.SystemParametersInfoW(action, uiParam, pvParam);
+return user32.SystemParametersInfoW(action, uiParam, pvParam, 0);

--- a/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiChildProcess.js
@@ -1,0 +1,43 @@
+/*
+ * SPI Child Process.
+ * This is executed by gpii.windows.spi.callProblematicSpi, in order to invoke certain problematic SET calls to
+ * SystemParametersInfo in a separate process. The exit code is the return value of the function.
+ *
+ * Copyright 2016 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var ffi = require("ffi");
+
+// 0 if uiParam is a block of data, otherwise it's a literal value.
+var pvParamPrimitive = process.env.GPII_SPI_PVPARAM_PRIMITIVE;
+var action = process.env.GPII_SPI_ACTION;
+var uiParam = process.env.GPII_SPI_UIPARAM;
+
+var pvParam, type;
+if (pvParamPrimitive) {
+    type = "uint32";
+    pvParam = process.env.GPII_SPI_PVPARAM;
+} else {
+    type = "void*";
+    pvParam = new Buffer(process.env.GPII_SPI_PVPARAM);
+}
+
+var user32 = ffi.Library("user32", {
+    "SystemParametersInfoW": [
+        "int32", ["uint32", "uint32", type, "uint32"]
+    ]
+});
+
+return user32.SystemParametersInfoW(action, uiParam, pvParam);

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -149,10 +149,11 @@ gpii.windows.spi.callProblematicSpi = function (pvParamType, action, uiParam, pv
             GPII_SPI_UIPARAM: uiParam,
             GPII_SPI_PVPARAM_PRIMITIVE: primitiveType ? 1 : 0,
             GPII_SPI_PVPARAM: primitiveType ? pvParam : pvParam.toString("hex")
-        }
+        },
+        execArgv: []
     };
 
-    var child = cp.fork(__dirname + "/setNonClientMetrics.js", null, options);
+    var child = cp.fork(__dirname + "/SpiChildProcess.js", options);
     var promise = fluid.promise();
 
     var timer = setTimeout(function () {

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -121,6 +121,65 @@ gpii.windows.spi.waitForSpi = function (action) {
     }
 };
 
+/**
+ * Performs the SPI call in a child-process. This is used on certain SPI_SET* calls to SPI that are known to be
+ * troublesome and have the potential to hang.
+ *
+ * See GPII-2001 for an example, where a system process causes this phenomenon. While it may be possible to fix that
+ * particular issue, it raises the question: what prevents other processes from doing the same? To work around this,
+ * the call to SystemParametersInfo (for problematic actions) shall be invoked in a separate process.
+ *
+ * A promise is returned, resolving with the return value of the SystemParametersInfo, or rejects if the call does not
+ * complete in a timely manner.
+ *
+ * @param pvParamType The data type of pvParam.
+ * @param action The uiAction SPI parameter.
+ * @param uiParam The uiParam SPI parameter.
+ * @param pvParam The pvParam SPI parameter.
+ * @return {promise} Rejects if the SPI call hangs.
+ */
+gpii.windows.spi.callProblematicSpi = function (pvParamType, action, uiParam, pvParam) {
+    var cp = require("child_process");
+
+    var primitiveType = pvParamType in gpii.windows.types;
+
+    var options = {
+        env: {
+            GPII_SPI_ACTION: action,
+            GPII_SPI_UIPARAM: uiParam,
+            GPII_SPI_PVPARAM_PRIMITIVE: primitiveType ? 1 : 0,
+            GPII_SPI_PVPARAM: primitiveType ? pvParam : pvParam.toString("hex")
+        }
+    };
+
+    var child = cp.fork(__dirname + "/setNonClientMetrics.js", null, options);
+    var promise = fluid.promise();
+
+    var timer = setTimeout(function () {
+        child.kill();
+        timer = null;
+    }, 10000);
+
+    child.on("exit", function (code) {
+        if (timer) {
+            clearTimeout(timer);
+        }
+
+        if (code === null) {
+            // The child process was killed.
+            fluid.log("SPI call has failed");
+            promise.reject({
+                isError: true,
+                message: "Timed out waiting for the SPI call to complete"
+            });
+        } else {
+            promise.resolve(code);
+        }
+    });
+
+    return promise;
+};
+
 
 /**
  * Applies the settings stored in the payload, making a call to SystemParametersInfoW with the
@@ -138,16 +197,27 @@ gpii.windows.spi.applySettings = function (payload) {
 
     var promiseTogo = fluid.promise();
 
+    // The SPI_SET* calls that could potentially halt the process.
+    var problematicSpiCalls = [
+        gpii.windows.actionConstants.SPI_SETNONCLIENTMETRICS
+    ];
+
     // Wait for sethc.exe to end before making the SPI call
     gpii.windows.spi.waitForSpi()
         .then(function () {
-            var callSuccessful = gpii.windows.spi.systemParametersInfo(pvParamType, action, uiParam, pvParam);
 
-            if (callSuccessful) {
-                fluid.promise.follow(gpii.windows.spi.waitForSpi(action), promiseTogo);
+            if (problematicSpiCalls.indexOf(action) >= 0) {
+                var p = gpii.windows.spi.callProblematicSpi(pvParamType, action, uiParam, pvParam);
+                fluid.promise.follow(p,  promiseTogo);
             } else {
-                var errorCode = gpii.windows.kernel32.GetLastError();
-                fluid.fail("SpiSettingsHandler.js: spi.applySettings() failed with error code " + errorCode + ".");
+                var callSuccessful = gpii.windows.spi.systemParametersInfo(pvParamType, action, uiParam, pvParam);
+
+                if (callSuccessful) {
+                    fluid.promise.follow(gpii.windows.spi.waitForSpi(action), promiseTogo);
+                } else {
+                    var errorCode = gpii.windows.kernel32.GetLastError();
+                    fluid.fail("SpiSettingsHandler.js: spi.applySettings() failed with error code " + errorCode + ".");
+                }
             }
         });
 

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -377,7 +377,7 @@ gpii.windows.spi.setImpl = function (payload) {
             fluid.log("SPI settings handler SET returning results ", results);
 
             togo.resolve(results);
-        });
+        }, togo.reject);
 
 
 

--- a/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
@@ -54,8 +54,10 @@ fluid.each(testPayloads, function (name) {
                     jqUnit.assertDeepEq(name + " restored", oldSettings, gpii.windows.spi.getImpl(payload));
                     jqUnit.start();
                 });
+            }, function (reason) {
+                jqUnit.fail(reason && reason.message);
+                jqUnit.start();
             });
-
     });
 });
 


### PR DESCRIPTION
Worked around this problem by making the SPI_SETNONCLIENTMETRICS SPI call in a separate process. This will prevent the main process from being blocked.
