### PR TITLE
GPII-81: Windows keyboard settings not implemented in solution registry

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -205,6 +205,25 @@ windows.NonClientMetrics = new Struct([
     ["int32", "iPaddedBorderWidth"]
 ]);
 windows.nonClientMetricsPointer = ref.refType(windows.NonClientMetrics);
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd373652(v=vs.85).aspx
+windows.StickyKeys = new Struct([
+    ["uint32",   "cbSize"],
+    ["uint32",   "dwFlags"]
+]);
+windows.StickyKeysPointer = ref.refType(windows.StickyKeys);
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd318079(v=vs.85).aspx
+windows.FilterKeys = new Struct([
+    ["uint32",   "cbSize"],
+    ["uint32",   "dwFlags"],
+    ["uint32",   "iWaitMSec"],
+    ["uint32",   "iDelayMSec"],
+    ["uint32",   "iRepeatMSec"],
+    ["uint32",   "iBounceMSec"]
+]);
+windows.FilterKeysPointer = ref.refType(windows.FilterKeys);
+
 // TODO Define additional structures used in calls to SystemParametersInfo here.
 
 /**
@@ -251,6 +270,7 @@ windows.flagConstants = {
     "SKF_AUDIBLEFEEDBACK": 0x00000040,
     "SKF_AVAILABLE":       0x00000002,
     "SKF_HOTKEYACTIVE":    0x00000004,
+    "SKF_STICKYKEYSON":    0x00000001,
 
     // FILTERKEYS flags
     // http://msdn.microsoft.com/en-us/library/windows/desktop/dd318079%28v=vs.85%29.aspx
@@ -272,7 +292,9 @@ windows.flagConstants = {
 windows.structures = {
     "HIGHCONTRAST":     windows.HighContrast,
     "NONCLIENTMETRICS": windows.NonClientMetrics,
-    "LOGFONT":          windows.LogFont
+    "LOGFONT":          windows.LogFont,
+    "STICKYKEYS":       windows.StickyKeys,
+    "FILTERKEYS":       windows.FilterKeys
     // TODO Add additional structures that we need to instantiate here.
 };
 

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -554,10 +554,11 @@ windows.accessFlag = function (object, flagName, setValue) {
 
     if (setValue !== undefined) {
         setValue = Boolean(setValue);
+        // The '>>>' operator is needed to convert the number back to an unsigned 32-bit int.
         if (setValue) {
-            object.dwFlags |= flagValue;
+            object.dwFlags = (object.dwFlags | flagValue) >>> 0;
         } else {
-            object.dwFlags &= ~flagValue;
+            object.dwFlags = (object.dwFlags & ~flagValue) >>> 0;
         }
     }
 

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -224,6 +224,18 @@ windows.FilterKeys = new Struct([
 ]);
 windows.FilterKeysPointer = ref.refType(windows.FilterKeys);
 
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd373593(v=vs.85).aspx
+windows.MouseKeys = new Struct([
+    ["uint32",   "cbSize"],
+    ["uint32",   "dwFlags"],
+    ["uint32",   "iMaxSpeed"],
+    ["uint32",   "iTimeToMaxSpeed"],
+    ["uint32",   "iCtrlSpeed"],
+    ["uint32",   "dwReserved1"],
+    ["uint32",   "dwReserved2"]
+]);
+windows.MouseKeysPointer = ref.refType(windows.MouseKeys);
+
 // TODO Define additional structures used in calls to SystemParametersInfo here.
 
 /**
@@ -242,6 +254,8 @@ windows.actionConstants = {
     "SPI_SETFILTERKEYS":       0x0033,
     "SPI_GETMOUSE":            0x0003,
     "SPI_SETMOUSE":            0x0004,
+    "SPI_GETMOUSEKEYS":        0x0036,
+    "SPI_SETMOUSEKEYS":        0x0037,
     "SPI_GETMOUSECLICKLOCK":   0x101E,
     "SPI_SETMOUSECLICKLOCK":   0x101F,
 
@@ -280,7 +294,23 @@ windows.flagConstants = {
     "FKF_FILTERKEYSON":    0x00000001,
     "FKF_HOTKEYACTIVE":    0x00000004,
     "FKF_HOTKEYSOUND":     0x00000010,
-    "FKF_INDICATOR":       0x00000020
+    "FKF_INDICATOR":       0x00000020,
+
+    // MOUSEKEYS flags
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd373593(v=vs.85).aspx
+    "MKF_AVAILABLE":       0x00000002,
+    "MKF_CONFIRMHOTKEY":   0x00000008,
+    "MKF_HOTKEYACTIVE":    0x00000004,
+    "MKF_HOTKEYSOUND":     0x00000010,
+    "MKF_INDICATOR":       0x00000020,
+    "MKF_LEFTBUTTONDOWN":  0x01000000,
+    "MKF_LEFTBUTTONSEL":   0x10000000,
+    "MKF_MODIFIERS":       0x00000040,
+    "MKF_MOUSEKEYSON":     0x00000001,
+    "MKF_MOUSEMODE":       0x80000000,
+    "MKF_REPLACENUMBERS":  0x00000080,
+    "MKF_RIGHTBUTTONDOWN": 0x02000000,
+    "MKF_RIGHTBUTTONSEL":  0x20000000
 
     // TODO Define additional flags used across various structures here.
 };
@@ -294,7 +324,8 @@ windows.structures = {
     "NONCLIENTMETRICS": windows.NonClientMetrics,
     "LOGFONT":          windows.LogFont,
     "STICKYKEYS":       windows.StickyKeys,
-    "FILTERKEYS":       windows.FilterKeys
+    "FILTERKEYS":       windows.FilterKeys,
+    "MOUSEKEYS":        windows.MouseKeys
     // TODO Add additional structures that we need to instantiate here.
 };
 

--- a/gpii/node_modules/spiSettingsHandler/test/testMouseKeys.json
+++ b/gpii/node_modules/spiSettingsHandler/test/testMouseKeys.json
@@ -1,0 +1,47 @@
+{
+    "options": {
+        "getAction": "SPI_GETMOUSEKEYS",
+        "setAction": "SPI_SETMOUSEKEYS",
+        "uiParam": "struct_size",
+        "pvParam": {
+            "type": "struct",
+            "name": "MOUSEKEYS",
+            "template": {
+                "cbSize": "uint32",
+                "dwFlags": "uint32",
+                "iMaxSpeed": "uint32",
+                "iTimeToMaxSpeed": "uint32",
+                "iCtrlSpeed": "uint32",
+                "dwReserved1": "uint32",
+                "dwReserved2": "uint32"
+            }
+        }
+    },
+
+    "settings": {
+        "FilterKeysAvailable": {
+            "value": true,
+            "path": "pvParam.dwFlags.MKF_AVAILABLE"
+        },
+
+        "MouseKeysOn": {
+            "value": false,
+            "path": "pvParam.dwFlags.MKF_MOUSEKEYSON"
+        },
+
+        "MaxSpeed": {
+            "value": 100,
+            "path": "pvParam.iMaxSpeed"
+        },
+
+        "Acceleration": {
+            "value": 1000,
+            "path": "pvParam.iTimeToMaxSpeed"
+        },
+
+        "CtrlSpeed": {
+            "value": 2,
+            "path": "pvParam.iCtrlSpeed"
+        }
+    }
+}

--- a/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
@@ -26,7 +26,8 @@ require("../src/SpiSettingsHandler.js");
 
 jqUnit.module("SpiSettingsHandler Module");
 
-var testPayloads = ["testMouseTrails", "testFilterKeys", "testMouse", "testMouseClickLock", "testLogFont", "testNonClientMetrics", "testStickyKeys", "testHighContrast", "testHighContrastToEmpty"];
+var testPayloads = ["testMouseTrails", "testFilterKeys", "testMouse", "testMouseClickLock", "testLogFont",
+    "testNonClientMetrics", "testStickyKeys", "testHighContrast", "testHighContrastToEmpty", "testMouseKeys"];
 
 fluid.each(testPayloads, function (name) {
 


### PR DESCRIPTION
This implements slow keys, bounce keys, sticky keys and mouse emulation on windows.

See also https://github.com/GPII/universal/pull/475