### PR TITLE
GPII-2085 - Provision Node.js LTS branch by default

### DIFF
--- a/provisioning/Chocolatey.ps1
+++ b/provisioning/Chocolatey.ps1
@@ -6,8 +6,16 @@ Import-Module (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'Prov
 $chocolatey = "$env:ChocolateyInstall\bin\choco.exe" -f $env:SystemDrive
 
 $nodePath = "C:\Program Files (x86)\nodejs"
-$nodeVersion = "6.9.1"
-Invoke-Command $chocolatey "install nodejs.install --version $($nodeVersion) --forcex86 -y"
+
+# Define the desired Node.js version (otherwise leave empty for latest LTS version)
+#$nodeVersion = "6.9.2"
+
+if($nodeVersion) {
+  Invoke-Command $chocolatey "install nodejs-lts --version $($nodeVersion) --forcex86 -y"
+} else {
+  Invoke-Command $chocolatey "install nodejs-lts --forcex86 -y"
+}
+
 # TODO: Correct path and automatically added is this one
 # C:\Users\vagrant\AppData\Roaming\npm review it.
 #Add-Path $nodePath $true


### PR DESCRIPTION
Traditionally, the Node.js package published in Chocolatey tracked the latest unstable version. To ensure we were using the LTS versions, the version had to be tracked manually.

On Dec 17th, a new package was published "nodejs-lts", which tracks the LTS versions automatically. This is equivalent to the "nodejs.install" package.

The downside is that this package started on version 6.9.2 so older versions are only available in the "nodejs.install" package. This should not be a problem for future work but might impact developers still using older versions.