### PR TITLE
GPII-2195 : Reverting GPII-1996 (8b02552) because it's not needed anymore.

### DIFF
--- a/provisioning/Chocolatey.ps1
+++ b/provisioning/Chocolatey.ps1
@@ -13,8 +13,6 @@ Invoke-Command $chocolatey "install nodejs.install --version $($nodeVersion) --f
 #Add-Path $nodePath $true
 refreshenv
 
-Invoke-Command "$($nodePath)\npm.cmd" "install node-gyp@3.4.0" "$($nodePath)\node_modules\npm"
-
 $python2Path = "C:\tools\python2"
 Invoke-Command $chocolatey "install python2 -y"
 Add-Path $python2Path $true


### PR DESCRIPTION
It's fixed in upstream and we are using fixed versions now so it's not needed we can drop it.