### PR TITLE
GPII-2200: Debug logging (for HST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 .vagrant
 **/test/*.exe
+/.version

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
 .vagrant
 **/test/*.exe
-/.version

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -122,6 +122,21 @@ windows.user32 = ffi.Library("user32", {
     ]
 });
 
+windows.advapi32 = ffi.Library("advapi32", {
+    // https://msdn.microsoft.com/library/aa376389.aspx
+    "CheckTokenMembership": [
+        t.BOOL, [t.HANDLE, t.HANDLE, t.PBOOL]
+    ],
+    // https://msdn.microsoft.com/library/aa375213.aspx
+    "AllocateAndInitializeSid": [
+        t.BOOL, ["void*", "char", t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.PVOID]
+    ],
+    // https://msdn.microsoft.com/library/aa446631.aspx
+    "FreeSid": [
+        t.PVOID, [t.HANDLE]
+    ]
+});
+
 /**
  * Gets a function pointer for an EnumWindowsProc callback for EnumWindows.
  *
@@ -170,7 +185,12 @@ windows.API_constants = {
 
     // The AccessibilityTemp values; https://msdn.microsoft.com/library/windows/desktop/bb879984.aspx
     disableAT: 2,
-    enableAT: 3
+    enableAT: 3,
+
+    // https://msdn.microsoft.com/library/windows/desktop/aa379649.aspx
+    SECURITY_NT_AUTHORITY: Buffer.from([0, 0, 0, 0, 0, 5]),
+    SECURITY_BUILTIN_DOMAIN_RID: 0x20,
+    DOMAIN_ALIAS_RID_ADMINS: 0x220
 };
 
 fluid.each(windows.API_constants.returnCodesLookup, function (value, key) {
@@ -749,6 +769,36 @@ windows.waitForCondition = function (func, options) {
 
     checkCondition();
     return promise;
+};
+
+/**
+ * Determines whether the process is running as an administrator, or if UAC is OFF.
+ *
+ * Inspired by the example code for CheckTokenMembership; https://msdn.microsoft.com/library/aa376389.aspx
+ *
+ * @return {Boolean} true if the node process is being ran as an administrator. undefined if the check failed.
+ */
+windows.isUserAdmin = function () {
+
+    var sid = ref.alloc(windows.types.ULONG_PTR);
+
+    // Create the sid for the local administrators group.
+    var ret = windows.advapi32.AllocateAndInitializeSid(c.SECURITY_NT_AUTHORITY, 2, c.SECURITY_BUILTIN_DOMAIN_RID,
+        c.DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, sid);
+
+    var togo;
+    if (ret) {
+        var isAdmin = ref.alloc(windows.types.BOOL);
+        // See if the thread's token is a member of the sid
+        var success = windows.advapi32.CheckTokenMembership(0, sid.deref(), isAdmin);
+        if (success) {
+            togo = !!isAdmin.deref();
+        }
+
+        windows.advapi32.FreeSid(sid);
+    }
+
+    return togo;
 };
 
 exports.windows = windows;

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -103,7 +103,11 @@ windows.kernel32 = ffi.Library("kernel32", {
     ],
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684139.aspx
     "IsWow64Process": [
-        t.BOOL,  [t.INT, t.PBOOL ]
+        t.BOOL, [t.INT, t.PBOOL ]
+    ],
+    // https://msdn.microsoft.com/library/ms684919.aspx
+    "QueryFullProcessImageNameW": [
+        t.BOOL, [t.HANDLE, t.DWORD, "char*", t.LPDWORD ]
     ]
 });
 
@@ -171,6 +175,7 @@ windows.API_constants = {
 
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880%28v=vs.85%29.aspx
     PROCESS_TERMINATE: 0x0001,
+    PROCESS_QUERY_LIMITED_INFORMATION: 0x1000,
 
     // http://stackoverflow.com/questions/23452271/is-max-path-always-same-size-even-if-unicode-macro-is-defined
     MAX_PATH: 260,

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -194,7 +194,7 @@ gpii.windows.debugLog.logRunningProcesses = function (options) {
 
     var output = outputLines.join("\n");
 
-    gpii.windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage("Running Processes:\n" + output, options);
 
     return output;
 };

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -19,7 +19,10 @@
 "use strict";
 
 var fluid = require("universal");
+var ref = require("ref");
+
 require("../WindowsUtilities/WindowsUtilities.js");
+require("../processHandling/processHandling.js");
 require("../registrySettingsHandler");
 
 var gpii = fluid.registerNamespace("gpii");
@@ -28,7 +31,7 @@ var windows = fluid.registerNamespace("gpii.windows");
 var debugLogLevel = fluid.logLevel.IMPORTANT;
 
 gpii.windows.logDebugInfo = function () {
-    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture"];
+    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses"];
 
     for (var n = 0, len = funcs.length; n < len; n++) {
         gpii.windows[funcs[n]]();
@@ -98,5 +101,44 @@ gpii.windows.logArchitecture = function (options) {
     return output;
 };
 
+/**
+ * Logs the currently running processes.
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logRunningProcesses = function (options) {
+    options = options || {};
+
+    var procs = windows.getRunningProcesses();
+
+    var outputLines = fluid.transform(procs, function (proc) {
+        // Get the full path of the executable
+        var exePath = proc.exeFile;
+        var hProcess = windows.kernel32.OpenProcess(windows.API_constants.PROCESS_QUERY_LIMITED_INFORMATION, 0, proc.pid);
+        if (hProcess) {
+            var size = ref.alloc(windows.types.DWORD);
+            size.writeUInt32LE(0x800, 0);
+            var path = new Buffer(0x800);
+            path.fill(0);
+            var success = windows.kernel32.QueryFullProcessImageNameW(hProcess, 0, path, size);
+            if (success) {
+                exePath = windows.fromWideChar(path);
+            }
+            windows.kernel32.CloseHandle(hProcess);
+        }
+
+        return exePath;
+    });
+
+    var output = outputLines.join("\n");
+
+    if (!options.quiet) {
+        fluid.log(debugLogLevel, output);
+    }
+
+    return output;
+};
 
 gpii.windows.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -8,9 +8,11 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
- * The research leading to these results has received funding from the European Union's
- * Seventh Framework Programme (FP7/2007-2013)
- * under grant agreement no. 289016.
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
  *
  * You may obtain a copy of the License at
  * https://github.com/GPII/universal/blob/master/LICENSE.txt

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -218,5 +218,3 @@ gpii.windows.debugLog.logArchitecture = function (options) {
 
     return output;
 };
-
-gpii.windows.debugLog.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -20,6 +20,7 @@
 
 var fluid = require("universal");
 var ref = require("ref");
+var fs = require("fs");
 
 require("../WindowsUtilities/WindowsUtilities.js");
 require("../processHandling/processHandling.js");
@@ -31,13 +32,49 @@ var windows = fluid.registerNamespace("gpii.windows");
 var debugLogLevel = fluid.logLevel.IMPORTANT;
 
 gpii.windows.logDebugInfo = function () {
-    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses"];
+    var funcs = [ "logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
+
+    var origLogSize = fluid.logObjectRenderChars;
+    fluid.logObjectRenderChars = 0xffff;
 
     for (var n = 0, len = funcs.length; n < len; n++) {
         gpii.windows[funcs[n]]();
     }
+
+    fluid.logObjectRenderChars = origLogSize;
 };
 
+/**
+ * Logs the GPII version and revision.
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logVersion = function (options) {
+    options = options || {};
+
+    var root = fluid.module.resolvePath("%gpii-windows")
+
+    // package.json version
+    var content = fs.readFileSync(root + "/package.json");
+    var pkg = JSON.parse(content);
+    var output = "GPII Version " + pkg.version;
+
+    try {
+        // "real" version
+        content = fs.readFileSync(root + "/.version");
+        output += " " + content;
+    } catch (e) {
+        // Doesn't matter
+    }
+
+    if (!options.quiet) {
+        fluid.log(debugLogLevel, output);
+    }
+
+    return output;
+};
 /**
  * Logs the environment variables.
  *
@@ -140,5 +177,28 @@ gpii.windows.logRunningProcesses = function (options) {
 
     return output;
 };
+
+/**
+ * Logs the version of GPII
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logArchitecture = function (options) {
+    options = options || {};
+
+    var output = "Architecture: " + process.arch;
+    if (windows.isWow64()) {
+        output += " (on 64-bit OS)";
+    }
+
+    if (!options.quiet) {
+        fluid.log(debugLogLevel, output);
+    }
+
+    return output;
+};
+
 
 gpii.windows.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -1,0 +1,42 @@
+/*
+ * Debug logging.
+ * Writes some information about the process/system that could aid in debugging problems found during the Hardware
+ * Sensitivity Tests.
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("universal");
+var gpii = fluid.registerNamespace("gpii");
+
+/**
+ * Logs the environment variables.
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logEnvironment = function (options) {
+    options = options || {};
+
+    var output = JSON.stringify(process.env, null, 2);
+    if (!options.quiet) {
+        fluid.log("Environment variables", output);
+    }
+
+    return output;
+};
+
+gpii.windows.logEnvironment();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -29,14 +29,13 @@ require("../processHandling/processHandling.js");
 require("../registrySettingsHandler");
 
 var gpii = fluid.registerNamespace("gpii");
-var windows = fluid.registerNamespace("gpii.windows");
-windows.debugLog = fluid.registerNamespace("gpii.windows.debugLog");
+fluid.registerNamespace("gpii.windows.debugLog");
 
 /**
  * The logging level for the debug log entries.
  * @type {number}
  */
-windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
+gpii.windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
 
 /**
  * Logs some information for debugging:
@@ -46,13 +45,13 @@ windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
  * - The CPU architecture
  * - Running processes
  *
- * @param options {Object} Options
+ * @param options {Object} [Optional] Options
  * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  */
 gpii.windows.debugLog.logDebugInfo = function (options) {
     options = options || {};
 
-    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : windows.debugLog.logLevel;
+    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : gpii.windows.debugLog.logLevel;
     if (fluid.passLogLevel(logLevel)) {
         var funcs = ["logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses"];
 
@@ -76,7 +75,7 @@ gpii.windows.debugLog.logDebugInfo = function (options) {
  */
 gpii.windows.debugLog.logMessage = function (message, options) {
     options = options || {};
-    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : windows.debugLog.logLevel;
+    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : gpii.windows.debugLog.logLevel;
     fluid.log(logLevel, message);
 };
 
@@ -90,7 +89,7 @@ gpii.windows.debugLog.logMessage = function (message, options) {
 gpii.windows.debugLog.logVersion = function (options) {
     options = options || {};
 
-    var root = fluid.module.resolvePath("%gpii-windows")
+    var root = fluid.module.resolvePath("%gpii-windows");
 
     // package.json version
     var content = fs.readFileSync(root + "/package.json");
@@ -105,7 +104,7 @@ gpii.windows.debugLog.logVersion = function (options) {
         // Doesn't matter
     }
 
-    windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -124,7 +123,7 @@ gpii.windows.debugLog.logEnvironment = function (options) {
         output += name + "=" + value + "\n";
     });
 
-    windows.debugLog.logMessage("Environment variables\n" + output, options);
+    gpii.windows.debugLog.logMessage("Environment variables\n" + output, options);
 
     return output;
 };
@@ -140,12 +139,12 @@ gpii.windows.debugLog.logAdministrator = function (options) {
     options = options || {};
 
     // Note: it is possible to be running as a non-admin even though UAC is off, if the user is a non-admin user.
-    var isAdmin = windows.isUserAdmin();
-    var uacEnabled = windows.readRegistryKey("HKEY_LOCAL_MACHINE",
+    var isAdmin = gpii.windows.isUserAdmin();
+    var uacEnabled = gpii.windows.readRegistryKey("HKEY_LOCAL_MACHINE",
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", "EnableLUA", "REG_DWORD");
     var output = "Running as admin: " + (isAdmin ? "YES" : "NO") + ", UAC is " + (uacEnabled ? "ON" : "OFF");
 
-    windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -161,11 +160,11 @@ gpii.windows.debugLog.logArchitecture = function (options) {
     options = options || {};
 
     var output = "Architecture: " + process.arch;
-    if (windows.isWow64()) {
+    if (gpii.windows.isWow64()) {
         output += " (on 64-bit OS)";
     }
 
-    windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -180,22 +179,22 @@ gpii.windows.debugLog.logArchitecture = function (options) {
 gpii.windows.debugLog.logRunningProcesses = function (options) {
     options = options || {};
 
-    var procs = windows.getRunningProcesses();
+    var procs = gpii.windows.getRunningProcesses();
 
     var outputLines = fluid.transform(procs, function (proc) {
         // Get the full path of the executable
         var exePath = proc.exeFile;
-        var hProcess = windows.kernel32.OpenProcess(windows.API_constants.PROCESS_QUERY_LIMITED_INFORMATION, 0, proc.pid);
+        var hProcess = gpii.windows.kernel32.OpenProcess(gpii.windows.API_constants.PROCESS_QUERY_LIMITED_INFORMATION, 0, proc.pid);
         if (hProcess) {
-            var size = ref.alloc(windows.types.DWORD);
-            size.writeUInt32LE(windows.API_constants.MAX_PATH, 0);
-            var path = new Buffer(windows.API_constants.MAX_PATH);
+            var size = ref.alloc(gpii.windows.types.DWORD);
+            size.writeUInt32LE(gpii.windows.API_constants.MAX_PATH, 0);
+            var path = new Buffer(gpii.windows.API_constants.MAX_PATH);
 
-            var success = windows.kernel32.QueryFullProcessImageNameW(hProcess, 0, path, size);
+            var success = gpii.windows.kernel32.QueryFullProcessImageNameW(hProcess, 0, path, size);
             if (success) {
-                exePath = windows.fromWideChar(path);
+                exePath = gpii.windows.fromWideChar(path);
             }
-            windows.kernel32.CloseHandle(hProcess);
+            gpii.windows.kernel32.CloseHandle(hProcess);
         }
 
         return exePath;
@@ -203,7 +202,7 @@ gpii.windows.debugLog.logRunningProcesses = function (options) {
 
     var output = outputLines.join("\n");
 
-    windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -219,14 +218,13 @@ gpii.windows.debugLog.logArchitecture = function (options) {
     options = options || {};
 
     var output = "Architecture: " + process.arch;
-    if (windows.isWow64()) {
+    if (gpii.windows.isWow64()) {
         output += " (on 64-bit OS)";
     }
 
-    windows.debugLog.logMessage(output, options);
+    gpii.windows.debugLog.logMessage(output, options);
 
     return output;
 };
-
 
 gpii.windows.debugLog.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -30,30 +30,59 @@ require("../registrySettingsHandler");
 
 var gpii = fluid.registerNamespace("gpii");
 var windows = fluid.registerNamespace("gpii.windows");
+windows.debugLog = fluid.registerNamespace("gpii.windows.debugLog");
 
-var debugLogLevel = fluid.logLevel.IMPORTANT;
+/**
+ * The logging level for the debug log entries.
+ * @type {number}
+ */
+windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
 
-gpii.windows.logDebugInfo = function () {
+/**
+ * Logs some information for debugging:
+ * - Version
+ * - Environment variables
+ * - Whether or not the process is running as Administrator
+ * - The CPU architecture
+ * - Running processes
+ *
+ * @param [options] Options
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ */
+gpii.windows.debugLog.logDebugInfo = function (options) {
     var funcs = [ "logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
 
     var origLogSize = fluid.logObjectRenderChars;
     fluid.logObjectRenderChars = 0xffff;
 
     for (var n = 0, len = funcs.length; n < len; n++) {
-        gpii.windows[funcs[n]]();
+        gpii.windows.debugLog[funcs[n]](options);
     }
 
     fluid.logObjectRenderChars = origLogSize;
 };
 
 /**
+ * Logs the given message.
+ *
+ * @param {String} message The log entry.
+ * @param [options] Options
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ */
+gpii.windows.debugLog.logMessage = function (message, options) {
+    options = options || {};
+    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : windows.debugLog.logLevel;
+    fluid.log(logLevel, message);
+};
+
+/**
  * Logs the GPII version and revision.
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logVersion = function (options) {
+gpii.windows.debugLog.logVersion = function (options) {
     options = options || {};
 
     var root = fluid.module.resolvePath("%gpii-windows")
@@ -72,7 +101,7 @@ gpii.windows.logVersion = function (options) {
     }
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, output);
+        windows.debugLog.logMessage(output, options);
     }
 
     return output;
@@ -81,10 +110,10 @@ gpii.windows.logVersion = function (options) {
  * Logs the environment variables.
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logEnvironment = function (options) {
+gpii.windows.debugLog.logEnvironment = function (options) {
     options = options || {};
 
     var output = "";
@@ -93,7 +122,7 @@ gpii.windows.logEnvironment = function (options) {
     });
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, "Environment variables", output);
+        windows.debugLog.logMessage("Environment variables\n" + output, options);
     }
 
     return output;
@@ -103,10 +132,10 @@ gpii.windows.logEnvironment = function (options) {
  * Logs whether or not the process is being run as an administrator, and whether UAC is on.
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logAdministrator = function (options) {
+gpii.windows.debugLog.logAdministrator = function (options) {
     options = options || {};
 
     // Note: it is possible to be running as a non-admin even though UAC is off, if the user is a non-admin user.
@@ -116,7 +145,7 @@ gpii.windows.logAdministrator = function (options) {
     var output = "Running as admin: " + (isAdmin ? "YES" : "NO") + ", UAC is " + (uacEnabled ? "ON" : "OFF");
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, output);
+        windows.debugLog.logMessage(output, options);
     }
 
     return output;
@@ -126,10 +155,10 @@ gpii.windows.logAdministrator = function (options) {
  * Logs the CPU architecture the process is running on.
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logArchitecture = function (options) {
+gpii.windows.debugLog.logArchitecture = function (options) {
     options = options || {};
 
     var output = "Architecture: " + process.arch;
@@ -138,7 +167,7 @@ gpii.windows.logArchitecture = function (options) {
     }
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, output);
+        windows.debugLog.logMessage(output, options);
     }
 
     return output;
@@ -148,10 +177,10 @@ gpii.windows.logArchitecture = function (options) {
  * Logs the currently running processes.
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logRunningProcesses = function (options) {
+gpii.windows.debugLog.logRunningProcesses = function (options) {
     options = options || {};
 
     var procs = windows.getRunningProcesses();
@@ -178,7 +207,7 @@ gpii.windows.logRunningProcesses = function (options) {
     var output = outputLines.join("\n");
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, output);
+        windows.debugLog.logMessage(output, options);
     }
 
     return output;
@@ -188,10 +217,10 @@ gpii.windows.logRunningProcesses = function (options) {
  * Logs the version of GPII
  *
  * @param [options] Options
- * @param {String} options.quiet Set to true to create no output.
+ * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
-gpii.windows.logArchitecture = function (options) {
+gpii.windows.debugLog.logArchitecture = function (options) {
     options = options || {};
 
     var output = "Architecture: " + process.arch;
@@ -200,11 +229,11 @@ gpii.windows.logArchitecture = function (options) {
     }
 
     if (!options.quiet) {
-        fluid.log(debugLogLevel, output);
+        windows.debugLog.logMessage(output, options);
     }
 
     return output;
 };
 
 
-gpii.windows.logDebugInfo();
+gpii.windows.debugLog.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -80,7 +80,7 @@ gpii.windows.debugLog.logMessage = function (message, options) {
 };
 
 /**
- * Logs the GPII version and revision.
+ * Logs the GPII version, from package.json.
  *
  * @param options {Object} [Optional] Options
  * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
@@ -91,18 +91,10 @@ gpii.windows.debugLog.logVersion = function (options) {
 
     var root = fluid.module.resolvePath("%gpii-windows");
 
-    // package.json version
+    // Read the version from package.json
     var content = fs.readFileSync(root + "/package.json");
     var pkg = JSON.parse(content);
     var output = "GPII Version " + pkg.version;
-
-    try {
-        // "real" version
-        content = fs.readFileSync(root + "/.version");
-        output += " " + content;
-    } catch (e) {
-        // Doesn't matter
-    }
 
     gpii.windows.debugLog.logMessage(output, options);
 

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -28,7 +28,7 @@ var windows = fluid.registerNamespace("gpii.windows");
 var debugLogLevel = fluid.logLevel.IMPORTANT;
 
 gpii.windows.logDebugInfo = function () {
-    var funcs = [ "logEnvironment", "logAdministrator"];
+    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture"];
 
     for (var n = 0, len = funcs.length; n < len; n++) {
         gpii.windows[funcs[n]]();
@@ -76,6 +76,27 @@ gpii.windows.logAdministrator = function (options) {
     return output;
 };
 
+/**
+ * Logs the CPU architecture the process is running on.
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logArchitecture = function (options) {
+    options = options || {};
+
+    var output = "Architecture: " + process.arch;
+    if (windows.isWow64()) {
+        output += " (on 64-bit OS)";
+    }
+
+    if (!options.quiet) {
+        fluid.log(debugLogLevel, output);
+    }
+
+    return output;
+};
 
 
 gpii.windows.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -46,8 +46,8 @@ windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
  * - The CPU architecture
  * - Running processes
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  */
 gpii.windows.debugLog.logDebugInfo = function (options) {
     options = options || {};
@@ -70,9 +70,9 @@ gpii.windows.debugLog.logDebugInfo = function (options) {
 /**
  * Logs the given message.
  *
- * @param {String} message The log entry.
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param message {String} The log entry.
+ * @param options {Object} Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  */
 gpii.windows.debugLog.logMessage = function (message, options) {
     options = options || {};
@@ -83,8 +83,8 @@ gpii.windows.debugLog.logMessage = function (message, options) {
 /**
  * Logs the GPII version and revision.
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} [Optional] Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logVersion = function (options) {
@@ -112,8 +112,8 @@ gpii.windows.debugLog.logVersion = function (options) {
 /**
  * Logs the environment variables.
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logEnvironment = function (options) {
@@ -132,8 +132,8 @@ gpii.windows.debugLog.logEnvironment = function (options) {
 /**
  * Logs whether or not the process is being run as an administrator, and whether UAC is on.
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} [Optional] Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logAdministrator = function (options) {
@@ -153,8 +153,8 @@ gpii.windows.debugLog.logAdministrator = function (options) {
 /**
  * Logs the CPU architecture the process is running on.
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} [Optional] Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logArchitecture = function (options) {
@@ -173,8 +173,8 @@ gpii.windows.debugLog.logArchitecture = function (options) {
 /**
  * Logs the currently running processes.
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} [Optional] Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logRunningProcesses = function (options) {
@@ -211,8 +211,8 @@ gpii.windows.debugLog.logRunningProcesses = function (options) {
 /**
  * Logs the version of GPII
  *
- * @param [options] Options
- * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
+ * @param options {Object} [Optional] Options
+ * @param options.logLevel {String} The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  * @return {String} Returns a string containing the debug information.
  */
 gpii.windows.debugLog.logArchitecture = function (options) {

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -85,7 +85,11 @@ gpii.windows.logVersion = function (options) {
 gpii.windows.logEnvironment = function (options) {
     options = options || {};
 
-    var output = JSON.stringify(process.env, null, 2);
+    var output = "";
+    fluid.each(process.env, function (value, name) {
+        output += name + "=" + value + "\n";
+    });
+
     if (!options.quiet) {
         fluid.log(debugLogLevel, "Environment variables", output);
     }
@@ -156,9 +160,9 @@ gpii.windows.logRunningProcesses = function (options) {
         var hProcess = windows.kernel32.OpenProcess(windows.API_constants.PROCESS_QUERY_LIMITED_INFORMATION, 0, proc.pid);
         if (hProcess) {
             var size = ref.alloc(windows.types.DWORD);
-            size.writeUInt32LE(0x800, 0);
-            var path = new Buffer(0x800);
-            path.fill(0);
+            size.writeUInt32LE(windows.API_constants.MAX_PATH, 0);
+            var path = new Buffer(windows.API_constants.MAX_PATH);
+
             var success = windows.kernel32.QueryFullProcessImageNameW(hProcess, 0, path, size);
             if (success) {
                 exePath = windows.fromWideChar(path);

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -50,16 +50,21 @@ windows.debugLog.logLevel = fluid.logLevel.IMPORTANT;
  * @param {String} options.logLevel The log level to use, instead of windows.debugLog.logLevel (See fluid.logLevelsSpec)
  */
 gpii.windows.debugLog.logDebugInfo = function (options) {
-    var funcs = [ "logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
+    options = options || {};
 
-    var origLogSize = fluid.logObjectRenderChars;
-    fluid.logObjectRenderChars = 0xffff;
+    var logLevel = fluid.isLogLevel(options.logLevel) ? options.logLevel : windows.debugLog.logLevel;
+    if (fluid.passLogLevel(logLevel)) {
+        var funcs = ["logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses"];
 
-    for (var n = 0, len = funcs.length; n < len; n++) {
-        gpii.windows.debugLog[funcs[n]](options);
+        var origLogSize = fluid.logObjectRenderChars;
+        fluid.logObjectRenderChars = 0xffff;
+
+        for (var n = 0, len = funcs.length; n < len; n++) {
+            gpii.windows.debugLog[funcs[n]](options);
+        }
+
+        fluid.logObjectRenderChars = origLogSize;
     }
-
-    fluid.logObjectRenderChars = origLogSize;
 };
 
 /**

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -19,7 +19,21 @@
 "use strict";
 
 var fluid = require("universal");
+require("../WindowsUtilities/WindowsUtilities.js");
+require("../registrySettingsHandler");
+
 var gpii = fluid.registerNamespace("gpii");
+var windows = fluid.registerNamespace("gpii.windows");
+
+var debugLogLevel = fluid.logLevel.IMPORTANT;
+
+gpii.windows.logDebugInfo = function () {
+    var funcs = [ "logEnvironment", "logAdministrator"];
+
+    for (var n = 0, len = funcs.length; n < len; n++) {
+        gpii.windows[funcs[n]]();
+    }
+};
 
 /**
  * Logs the environment variables.
@@ -33,10 +47,35 @@ gpii.windows.logEnvironment = function (options) {
 
     var output = JSON.stringify(process.env, null, 2);
     if (!options.quiet) {
-        fluid.log("Environment variables", output);
+        fluid.log(debugLogLevel, "Environment variables", output);
     }
 
     return output;
 };
 
-gpii.windows.logEnvironment();
+/**
+ * Logs whether or not the process is being run as an administrator, and whether UAC is on.
+ *
+ * @param [options] Options
+ * @param {String} options.quiet Set to true to create no output.
+ * @return {String} Returns a string containing the debug information.
+ */
+gpii.windows.logAdministrator = function (options) {
+    options = options || {};
+
+    // Note: it is possible to be running as a non-admin even though UAC is off, if the user is a non-admin user.
+    var isAdmin = windows.isUserAdmin();
+    var uacEnabled = windows.readRegistryKey("HKEY_LOCAL_MACHINE",
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", "EnableLUA", "REG_DWORD");
+    var output = "Running as admin: " + (isAdmin ? "YES" : "NO") + ", UAC is " + (uacEnabled ? "ON" : "OFF");
+
+    if (!options.quiet) {
+        fluid.log(debugLogLevel, output);
+    }
+
+    return output;
+};
+
+
+
+gpii.windows.logDebugInfo();

--- a/gpii/node_modules/debugLogger/debugLogger.js
+++ b/gpii/node_modules/debugLogger/debugLogger.js
@@ -105,9 +105,7 @@ gpii.windows.debugLog.logVersion = function (options) {
         // Doesn't matter
     }
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage(output, options);
-    }
+    windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -126,9 +124,7 @@ gpii.windows.debugLog.logEnvironment = function (options) {
         output += name + "=" + value + "\n";
     });
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage("Environment variables\n" + output, options);
-    }
+    windows.debugLog.logMessage("Environment variables\n" + output, options);
 
     return output;
 };
@@ -149,9 +145,7 @@ gpii.windows.debugLog.logAdministrator = function (options) {
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", "EnableLUA", "REG_DWORD");
     var output = "Running as admin: " + (isAdmin ? "YES" : "NO") + ", UAC is " + (uacEnabled ? "ON" : "OFF");
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage(output, options);
-    }
+    windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -171,9 +165,7 @@ gpii.windows.debugLog.logArchitecture = function (options) {
         output += " (on 64-bit OS)";
     }
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage(output, options);
-    }
+    windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -211,9 +203,7 @@ gpii.windows.debugLog.logRunningProcesses = function (options) {
 
     var output = outputLines.join("\n");
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage(output, options);
-    }
+    windows.debugLog.logMessage(output, options);
 
     return output;
 };
@@ -233,9 +223,7 @@ gpii.windows.debugLog.logArchitecture = function (options) {
         output += " (on 64-bit OS)";
     }
 
-    if (!options.quiet) {
-        windows.debugLog.logMessage(output, options);
-    }
+    windows.debugLog.logMessage(output, options);
 
     return output;
 };

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -20,8 +20,6 @@ var fluid = require("universal");
 
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
-var shelljs = require("shelljs");
-var path = require("path");
 
 require("../debugLogger.js");
 require("../../processHandling/processHandling.js");
@@ -35,12 +33,47 @@ jqUnit.test("Testing debugLogger", function () {
         quiet: true
     };
 
-    var funcs = [ "logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
-
     // Because these methods return information about the current system, it would be tricky to control or predict
-    // the output without effectively re-implementing them. This test just ensures they return a string and don't crash.
-    for (var n = 0, len = funcs.length; n < len; n++) {
-        var ret = gpii.windows[funcs[n]](options);
-        jqUnit.assertEquals("Return is a string", "string", typeof(ret));
+    // the output without effectively re-implementing them, so just search the results for certain expected keywords.
+    var tests = [
+        {
+            test: "logVersion",
+            expected: [ /[0-9]+\.[0-9]+\.[0-9]+/ ]
+        },
+        {
+            test: "logEnvironment",
+            expected: [ /PATH/i, /SYSTEMROOT/i, process.env.PATH, process.env.SYSTEMROOT ]
+        },
+        {
+            test: "logAdministrator",
+            expected: [ /(NO|YES).*UAC.*(ON|OFF)/i ]
+        },
+        {
+            test: "logArchitecture",
+            expected: [ /ia32|x64/ ]
+        },
+        {
+            test: "logRunningProcesses",
+            expected: [ "node.exe", "svchost.exe", "winlogon.exe" ]
+        }
+    ];
+
+    for (var n = 0; n < tests.length; n++) {
+        var test = tests[n].test;
+        var expected = tests[n].expected;
+
+        var result = gpii.windows[test](options);
+
+        jqUnit.assertEquals(test + ": Return is a string", "string", typeof(result));
+
+        for (var e = 0; e < expected.length; e++) {
+            var search = expected[e];
+
+            var success = typeof(search) === "string"
+                ? result.indexOf(search) > 1
+                : result.match(search);
+
+            jqUnit.assertTrue(test + ": Result should contain " + search, success);
+        }
     }
 });

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -1,0 +1,40 @@
+/*
+ * debugLogger Tests
+ *
+ * Copyright 2015 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("universal");
+
+var jqUnit = fluid.require("node-jqunit");
+var gpii = fluid.registerNamespace("gpii");
+var shelljs = require("shelljs");
+var path = require("path");
+
+require("../debugLogger.js");
+require("../../processHandling/processHandling.js");
+
+fluid.registerNamespace("gpii.tests.windows.debugLogger");
+
+jqUnit.module("gpii.tests.windows.debugLogger");
+
+jqUnit.test("Testing debugLogger", function () {
+    var options = {
+        quiet: true
+    };
+
+    var ret = gpii.windows.logEnvironment(options);
+    jqUnit.assertEquals("Return is a string", "string", typeof(ret));
+});

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -35,6 +35,13 @@ jqUnit.test("Testing debugLogger", function () {
         quiet: true
     };
 
-    var ret = gpii.windows.logEnvironment(options);
-    jqUnit.assertEquals("Return is a string", "string", typeof(ret));
+    var funcs = [ "logEnvironment", "logAdministrator"];
+
+    // Because these methods return information about the current system, it would be tricky to control or predict
+    // the output without effectively re-implementing them. This test just ensures they return a string and don't crash.
+    for (var n = 0, len = funcs.length; n < len; n++) {
+        var ret = gpii.windows[funcs[n]](options);
+        jqUnit.assertEquals("Return is a string", "string", typeof(ret));
+    }
+
 });

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -35,7 +35,7 @@ jqUnit.test("Testing debugLogger", function () {
         quiet: true
     };
 
-    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture" ];
+    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
 
     // Because these methods return information about the current system, it would be tricky to control or predict
     // the output without effectively re-implementing them. This test just ensures they return a string and don't crash.

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -35,7 +35,7 @@ jqUnit.test("Testing debugLogger", function () {
         quiet: true
     };
 
-    var funcs = [ "logEnvironment", "logAdministrator"];
+    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture" ];
 
     // Because these methods return information about the current system, it would be tricky to control or predict
     // the output without effectively re-implementing them. This test just ensures they return a string and don't crash.
@@ -43,5 +43,4 @@ jqUnit.test("Testing debugLogger", function () {
         var ret = gpii.windows[funcs[n]](options);
         jqUnit.assertEquals("Return is a string", "string", typeof(ret));
     }
-
 });

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -35,7 +35,7 @@ jqUnit.test("Testing debugLogger", function () {
         quiet: true
     };
 
-    var funcs = [ "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
+    var funcs = [ "logVersion", "logEnvironment", "logAdministrator", "logArchitecture", "logRunningProcesses" ];
 
     // Because these methods return information about the current system, it would be tricky to control or predict
     // the output without effectively re-implementing them. This test just ensures they return a string and don't crash.

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -1,14 +1,16 @@
 /*
  * debugLogger Tests
  *
- * Copyright 2015 Raising the Floor - International
+ * Copyright 2016 Raising the Floor - International
  *
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
- * The research leading to these results has received funding from the European Union's
- * Seventh Framework Programme (FP7/2007-2013)
- * under grant agreement no. 289016.
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
  *
  * You may obtain a copy of the License at
  * https://github.com/GPII/universal/blob/master/LICENSE.txt

--- a/gpii/node_modules/debugLogger/test/testDebugLogger.js
+++ b/gpii/node_modules/debugLogger/test/testDebugLogger.js
@@ -32,7 +32,7 @@ jqUnit.module("gpii.tests.windows.debugLogger");
 
 jqUnit.test("Testing debugLogger", function () {
     var options = {
-        quiet: true
+        logLevel: fluid.logLevel.TRACE
     };
 
     // Because these methods return information about the current system, it would be tricky to control or predict
@@ -64,7 +64,7 @@ jqUnit.test("Testing debugLogger", function () {
         var test = tests[n].test;
         var expected = tests[n].expected;
 
-        var result = gpii.windows[test](options);
+        var result = gpii.windows.debugLog[test](options);
 
         jqUnit.assertEquals(test + ": Return is a string", "string", typeof(result));
 

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -60,6 +60,24 @@ gpii.windows.killProcessByName = function (filename) {
  */
 gpii.windows.findProcessByName = function (filename, all) {
 
+    var filenameLower = filename.toLowerCase();
+    var processes = gpii.windows.getRunningProcesses().filter(function (proc) {
+        return proc.exeFile === filenameLower;
+    });
+
+    var togo = null;
+    if (processes.length > 0) {
+        if (all) {
+            togo = fluid.transform(processes, function (proc) {
+                return proc.pid;
+            });
+        } else {
+            togo = processes[0].pid;
+        }
+    }
+
+    return togo;
+
     // Get a snapshot of the processes.
     var hSnapShot = windows.kernel32.CreateToolhelp32Snapshot(windows.API_constants.TH32CS_SNAPPROCESS, null);
     if (hSnapShot === windows.API_constants.INVALID_HANDLE_VALUE) {
@@ -101,6 +119,44 @@ gpii.windows.findProcessByName = function (filename, all) {
     }
 
     return all ? matches : null;
+};
+
+gpii.windows.getRunningProcesses = function () {
+    // Get a snapshot of the processes.
+    var hSnapShot = windows.kernel32.CreateToolhelp32Snapshot(windows.API_constants.TH32CS_SNAPPROCESS, null);
+    if (hSnapShot === windows.API_constants.INVALID_HANDLE_VALUE) {
+        console.error("CreateToolhelp32Snapshot failed. Win32 error: " + windows.GetLastError());
+        return null;
+    }
+
+    var togo = [];
+
+    try {
+        // Create the structure for the return parameter of Process32First/Next.
+        var pEntry = new windows.PROCESSENTRY32();
+        pEntry.dwSize = windows.PROCESSENTRY32.size;
+
+        // Enumerate the processes.
+        var hRes = windows.kernel32.Process32First(hSnapShot, pEntry.ref());
+        while (hRes) {
+            var buf = new Buffer(pEntry.szExeFile);
+            var processName = ref.readCString(buf, 0);
+
+            togo.push({
+                pid: pEntry.th32ProcessID,
+                exeFile: processName
+            });
+
+            hRes = windows.kernel32.Process32Next(hSnapShot, pEntry.ref());
+        }
+    } finally {
+        // Make sure the snapshot is closed.
+        if (hSnapShot) {
+            windows.kernel32.CloseHandle(hSnapShot);
+        }
+    }
+
+    return togo;
 };
 
 /**

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -62,7 +62,7 @@ gpii.windows.findProcessByName = function (filename, all) {
 
     var filenameLower = filename.toLowerCase();
     var processes = gpii.windows.getRunningProcesses().filter(function (proc) {
-        return proc.exeFile === filenameLower;
+        return proc.exeFile.toLowerCase() === filenameLower;
     });
 
     var togo = null;

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -77,50 +77,13 @@ gpii.windows.findProcessByName = function (filename, all) {
     }
 
     return togo;
-
-    // Get a snapshot of the processes.
-    var hSnapShot = windows.kernel32.CreateToolhelp32Snapshot(windows.API_constants.TH32CS_SNAPPROCESS, null);
-    if (hSnapShot === windows.API_constants.INVALID_HANDLE_VALUE) {
-        console.error("CreateToolhelp32Snapshot failed. Win32 error: " + windows.GetLastError());
-        return null;
-    }
-
-    var matches = [];
-    var filenameLower = filename.toLowerCase();
-
-    try {
-        // Create the structure for the return parameter of Process32First/Next.
-        var pEntry = new windows.PROCESSENTRY32();
-        pEntry.dwSize = windows.PROCESSENTRY32.size;
-
-        // Enumerate the processes.
-        var hRes = windows.kernel32.Process32First(hSnapShot, pEntry.ref());
-        while (hRes) {
-            var buf = new Buffer(pEntry.szExeFile);
-            var processName = ref.readCString(buf, 0);
-
-            if (processName.toLowerCase() === filenameLower) {
-                if (all) {
-                    // Add it to the array of matches.
-                    matches.push(pEntry.th32ProcessID);
-                } else {
-                    // Only want the first one - return it.
-                    return pEntry.th32ProcessID;
-                }
-            }
-
-            hRes = windows.kernel32.Process32Next(hSnapShot, pEntry.ref());
-        }
-    } finally {
-        // Make sure the snapshot is closed.
-        if (hSnapShot) {
-            windows.kernel32.CloseHandle(hSnapShot);
-        }
-    }
-
-    return all ? matches : null;
 };
 
+/**
+ * Gets a list of the running processes.
+ *
+ * @return {Object[]} An array of objects containing the exeFile and pid for every process running.
+ */
 gpii.windows.getRunningProcesses = function () {
     // Get a snapshot of the processes.
     var hSnapShot = windows.kernel32.CreateToolhelp32Snapshot(windows.API_constants.TH32CS_SNAPPROCESS, null);

--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -45,6 +45,25 @@ jqUnit.module("gpii.tests.windows.processHandling", {
     }
 });
 
+jqUnit.test("Testing getRunningProcesses", function () {
+
+    var procs = gpii.windows.getRunningProcesses();
+
+    jqUnit.assertNotNull("getRunningProcesses should return something", procs);
+    jqUnit.assertTrue("There should be some processes running", procs.length > 0);
+
+    var p = procs[0];
+    jqUnit.assertEquals("pid should be a number", "number", typeof(p.pid));
+    jqUnit.assertEquals("exeFile should be a string", "string", typeof(p.exeFile));
+
+    var thisProc = fluid.find_if(procs, function (proc) {
+        return proc.pid === process.pid;
+    });
+
+    jqUnit.assertTrue("This process should be found", !!thisProc);
+
+});
+
 jqUnit.test("Testing findProcessByName", function () {
     // Find a process that isn't running.
     var pid = gpii.windows.findProcessByName("a non-matching process.exe");

--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -73,6 +73,10 @@ jqUnit.test("Testing findProcessByName", function () {
     pid = gpii.windows.findProcessByName("node.exe");
     jqUnit.assertNotEquals("Process should have been found running", null, pid);
 
+    // Check it's case-insensitive.
+    pid = gpii.windows.findProcessByName("[sysTEM proCESS]");
+    jqUnit.assertNotEquals("Process should have been found running (case ignored)", null, pid);
+
     // Find multiple processes. There's always more than one svchost.exe running on Windows.
     var pids = gpii.windows.findProcessByName("svchost.exe", true);
     jqUnit.assertTrue("Should have found several matching process.", pids.length > 1);

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ fluid.contextAware.makeChecks({
 
 require("./gpii/node_modules/WindowsUtilities/WindowsUtilities.js");
 require("./gpii/node_modules/processHandling/processHandling.js");
+require("./gpii/node_modules/debugLogger/debugLogger.js");
 require("./gpii/node_modules/displaySettingsHandler");
 require("./gpii/node_modules/registrySettingsHandler");
 require("./gpii/node_modules/registryResolver");

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
     "keywords": ["gpii", "accessibility", "settings", "fluid", "IoC", "Inversion of Control", "configuration", "evented"],
     "repository": "git://github.com/GPII/windows.git",
     "main": "./gpii.js",
-    "engines": { "node" : ">=6.3.1" },
-    "scripts": {
-        "preinstall": "git describe --long --always --all --dirty > .version"
-    }
+    "engines": { "node" : ">=6.3.1" }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "keywords": ["gpii", "accessibility", "settings", "fluid", "IoC", "Inversion of Control", "configuration", "evented"],
     "repository": "git://github.com/GPII/windows.git",
     "main": "./gpii.js",
-    "engines": { "node" : ">=6.3.1" }
+    "engines": { "node" : ">=6.3.1" },
+    "scripts": {
+        "preinstall": "git describe --long --always --all --dirty > .version"
+    }
 }

--- a/tests/UnitTests.js
+++ b/tests/UnitTests.js
@@ -20,3 +20,4 @@ require("../gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js"
 require("../gpii/node_modules/processHandling/test/testProcessHandling");
 require("../gpii/node_modules/registryResolver/test/testRegistryResolver.js");
 require("../gpii/node_modules/registeredAT/test/testRegisteredAT.js");
+require("../gpii/node_modules/debugLogger/test/testDebugLogger.js");


### PR DESCRIPTION
Added logging for the following:
- Some build/version identifier
- Is the user an admin?
- If the 64-bit node could be used, then the bitness of the process.
- Running processes
- Dump of the environment variables

It always logs this information, so it might be better to have a flag somewhere (or perhaps make use of the current log level setting)