### PR TITLE
GPII-2125: Use the closest available resolution when setting it

### DIFF
--- a/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
@@ -108,42 +108,56 @@ windows.display.getScreenResolution = function () {
 };
 
 /*
+ * Gets available resolutions
+ *
+ * @return {list} of resolutions
+ */
+windows.display.getAvailableResolutions = function () {
+    var index = 0;
+    var dm = windows.display.createDevModeStruct();
+    var availableResolutions = [];
+
+    while (windows.display.user32.EnumDisplaySettingsW(ref.NULL, index++, dm.ref()) !== c.FALSE) {
+        var curr = {
+            dmPelsWidth: dm.dmPelsWidth,
+            dmPelsHeight: dm.dmPelsHeight
+        };
+        availableResolutions.push(curr);
+    };
+
+    return availableResolutions;
+};
+
+/*
  * Sets the current display's screen resolution if possible
  *
  * @param {Object} The new screen resolution width and height
  * @return {boolean} true if successfu
  */
 windows.display.setScreenResolution = function (newRes) {
-    if (typeof(newRes.width) !== "number" || typeof(newRes.height) !== "number") {
+    if (typeof(newRes.width) !== "number" || typeof(newRes.height) !== "number" || newRes.width < 0 || newRes.height < 0) {
         fluid.fail("Received an invalid screen resolution: ", newRes);
     } else {
-        var index = 0;
-        var dm = windows.display.createDevModeStruct();
-
-        while (windows.display.user32.EnumDisplaySettingsW(ref.NULL, index++, dm.ref()) !== c.FALSE) {
-            if (dm.dmPelsWidth === newRes.width && dm.dmPelsHeight === newRes.height) {
-                var dmCurrent = windows.display.createDevModeStruct();
-
-                if (windows.display.user32.EnumDisplaySettingsW(ref.NULL, c.ENUM_CURRENT_SETTINGS, dmCurrent.ref()) !== c.FALSE) {
-                    // Note: ChangeDisplaySettings has no effect if new is same as current
-                    dmCurrent.dmPelsWidth = newRes.width;
-                    dmCurrent.dmPelsHeight = newRes.height;
-                    var lRet = windows.display.user32.ChangeDisplaySettingsW(dmCurrent.ref(), 0);
-                    if (lRet === c.DISP_CHANGE_SUCCESSFUL) {
-                        return true;
-                    } else if (lRet === c.DISP_CHANGE_RESTART) {
-                        // TODO: According to the returned code, the computer must be restarted for
-                        // the graphics mode to work. For now we return 'true', but this special case
-                        // is related to https://issues.gpii.net/browse/GPII-1982, and we must consider
-                        // this as something that needs to be taken into account and even notified to
-                        // the user.
-                        //
-                        return true;
-                    } else {
-                        // Return codes explained at https://msdn.microsoft.com/en-us/library/dd183411.aspx
-                        fluid.fail("Couldn't set screen resolution, return code was " + lRet);
-                    }
-                }
+        var dmCurrent = windows.display.createDevModeStruct();
+        var closestResolution = windows.display.findClosestResolution(newRes);
+        if (windows.display.user32.EnumDisplaySettingsW(ref.NULL, c.ENUM_CURRENT_SETTINGS, dmCurrent.ref()) !== c.FALSE) {
+            // Note: ChangeDisplaySettings has no effect if new is same as current
+            dmCurrent.dmPelsWidth = closestResolution.dmPelsWidth;
+            dmCurrent.dmPelsHeight = closestResolution.dmPelsHeight;
+            var lRet = windows.display.user32.ChangeDisplaySettingsW(dmCurrent.ref(), 0);
+            if (lRet === c.DISP_CHANGE_SUCCESSFUL) {
+                return true;
+            } else if (lRet === c.DISP_CHANGE_RESTART) {
+                // TODO: According to the returned code, the computer must be restarted for
+                // the graphics mode to work. For now we return 'true', but this special case
+                // is related to https://issues.gpii.net/browse/GPII-1982, and we must consider
+                // this as something that needs to be taken into account and even notified to
+                // the user.
+                //
+                return true;
+            } else {
+                // Return codes explained at https://msdn.microsoft.com/en-us/library/dd183411.aspx
+                fluid.fail("Couldn't set screen resolution, return code was " + lRet);
             }
         }
     }
@@ -182,4 +196,29 @@ windows.displaySettingsHandler.get = function (payload) {
 
 windows.displaySettingsHandler.set = function (payload) {
     return gpii.settingsHandlers.invokeSettingsHandler(windows.display.setImpl, payload);
+};
+
+// Internal utilities
+// TODO: Move this into gpii.settingsHandlerUtilities and add tests
+
+windows.display.calculateDistance = function (x, y) {
+    var a = x[0] - y[0];
+    var b = x[1] - y[1];
+    return Math.sqrt(a * a + b * b);
+};
+
+windows.display.findClosestResolution = function (res) {
+    var distance = null;
+    var closest = null;
+
+    var availableResolutions = windows.display.getAvailableResolutions();
+
+    fluid.each(availableResolutions, function (currRes) {
+        var currDist = windows.display.calculateDistance([res.width, res.height], [currRes.dmPelsWidth, currRes.dmPelsHeight]);
+        if (distance === null || currDist < distance) {
+            distance = currDist;
+            closest = currRes;
+        }
+    });
+    return closest;
 };

--- a/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
@@ -92,16 +92,34 @@ windows.display.createDevModeStruct = function () {
 };
 
 /*
+ * Returns if a screen resolution is invalid
+ *
+ * @param (Object)
+ * @returns {boolean} true if invalid
+ */
+windows.display.isInvalid = function (screenRes) {
+    var isInvalid = true;
+    if (typeof(screenRes.width) === "number" && typeof(screenRes.height) === "number" && screenRes.width > 0 && screenRes.height > 0) {
+        fluid.each(windows.display.getAvailableResolutions(), function (validScreenRes) {
+            if (validScreenRes.dmPelsWidth === screenRes.width && validScreenRes.dmPelsHeight === screenRes.height) {
+                isInvalid = false;
+            };
+        });
+    }
+    return isInvalid;
+};
+
+/*
  * Gets the current display's screen resolution
  *
  * @return {Object) The width and height of the screen.
  */
 windows.display.getScreenResolution = function () {
     var dm = windows.display.createDevModeStruct();
-
     if (windows.display.user32.EnumDisplaySettingsW(ref.NULL, c.ENUM_CURRENT_SETTINGS, dm.ref()) !== c.FALSE) {
         // note for unknown reason on win 10 the returned dmSize is 188 not expected 220
-        return { width: dm.dmPelsWidth, height: dm.dmPelsHeight };
+        var closestScreenRes = windows.display.findClosestResolution({width: dm.dmPelsWidth, height: dm.dmPelsHeight});
+        return { width: closestScreenRes.dmPelsWidth, height: closestScreenRes.dmPelsHeight };
     } else {
         fluid.fail("Couldn't retrieve the current screen resolution");
     }
@@ -135,15 +153,14 @@ windows.display.getAvailableResolutions = function () {
  * @return {boolean} true if successfu
  */
 windows.display.setScreenResolution = function (newRes) {
-    if (typeof(newRes.width) !== "number" || typeof(newRes.height) !== "number" || newRes.width < 0 || newRes.height < 0) {
+    if (windows.display.isInvalid(newRes)) {
         fluid.fail("Received an invalid screen resolution: ", newRes);
     } else {
         var dmCurrent = windows.display.createDevModeStruct();
-        var closestResolution = windows.display.findClosestResolution(newRes);
         if (windows.display.user32.EnumDisplaySettingsW(ref.NULL, c.ENUM_CURRENT_SETTINGS, dmCurrent.ref()) !== c.FALSE) {
             // Note: ChangeDisplaySettings has no effect if new is same as current
-            dmCurrent.dmPelsWidth = closestResolution.dmPelsWidth;
-            dmCurrent.dmPelsHeight = closestResolution.dmPelsHeight;
+            dmCurrent.dmPelsWidth = newRes.width;
+            dmCurrent.dmPelsHeight = newRes.height;
             var lRet = windows.display.user32.ChangeDisplaySettingsW(dmCurrent.ref(), 0);
             if (lRet === c.DISP_CHANGE_SUCCESSFUL) {
                 return true;

--- a/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
@@ -42,8 +42,10 @@ jqUnit.test("Testing setScreenResolution ", function () {
     jqUnit.assertDeepEq("New resolution is set", targetRes, newRes);
 
     // Restore old resolution
-    jqUnit.expect(1);
+    jqUnit.expect(2);
     jqUnit.assertTrue("Resetting to old resolution", gpii.windows.display.setScreenResolution(oldRes));
+    var restoredRes = gpii.windows.display.getScreenResolution();
+    jqUnit.assertDeepEq("Old resolution appear to be restored", oldRes, restoredRes);
 
     // test can't change to invalid resolution
     var badRes = { width: -123, height: -123 };

--- a/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
@@ -34,7 +34,7 @@ jqUnit.test("Testing setScreenResolution ", function () {
     var oldRes = gpii.windows.display.getScreenResolution();
 
     // We can change resolution
-    // Not such a good unit test as depends on available modes
+    // Not such a good unit test as depends on available modes and current screen resolution
     jqUnit.expect(2);
     var targetRes = { width: 800, height: 600 };
     jqUnit.assertTrue("We can call to setScreenResolution, it returns 'true'", gpii.windows.display.setScreenResolution(targetRes));
@@ -42,27 +42,26 @@ jqUnit.test("Testing setScreenResolution ", function () {
     jqUnit.assertDeepEq("New resolution is set", targetRes, newRes);
 
     // Restore old resolution
-    jqUnit.expect(2);
+    jqUnit.expect(1);
     jqUnit.assertTrue("Resetting to old resolution", gpii.windows.display.setScreenResolution(oldRes));
-    var restoredRes = gpii.windows.display.getScreenResolution();
-    jqUnit.assertDeepEq("Old resolution appear to be restored", oldRes, restoredRes);
 
     // test can't change to invalid resolution
-    jqUnit.expect(2);
     var badRes = { width: -123, height: -123 };
-    jqUnit.assertFalse("Expected setting invalid resolution to fail", gpii.windows.display.setScreenResolution(badRes));
-    var newRes2 = gpii.windows.display.getScreenResolution();
-    jqUnit.assertDeepEq("Reported resolution should not have changed", oldRes, newRes2);
+    jqUnit.expectFrameworkDiagnostic("setScreenResolution fails when receives an invalid resolution such as {w: -123, h: -123}", function () {
+        gpii.windows.display.setScreenResolution(badRes);
+    }, "invalid screen resolution");
 
     // test that setScreenResolution fails when it receives a faulty screen resolution
     var faulty1 = 2;
     jqUnit.expectFrameworkDiagnostic("setScreenResolution fails when receives a non-object parameter", function () {
         gpii.windows.display.setScreenResolution(faulty1);
     }, "invalid screen resolution");
+
     var faulty2 = { w: 0, h: 1 };
     jqUnit.expectFrameworkDiagnostic("setScreenResolution fails when receives a wrong object", function () {
         gpii.windows.display.setScreenResolution(faulty2);
     }, ["invalid screen resolution"]);
+
     var faulty3 = { width: 0, height: "" };
     jqUnit.expectFrameworkDiagnostic("setScreenResolution fails when receives one string as value for height", function () {
         gpii.windows.display.setScreenResolution(faulty3);


### PR DESCRIPTION
As described in GPII-2125, since we can't set the screen resolution to something that is not recognized as valid (VirtualBox does its own black magic when resizing), we at least should try to restore the resolution to the closest valid one.