### PR TITLE
GPII-2302: Replace calls to shelljs.exec

### DIFF
--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -109,7 +109,7 @@ jqUnit.asyncTest("Testing waiting for processes start and end", function () {
                 });
 
             // Tell the process to stop now.
-            shelljs.exec("waitfor /SI waitForProcessTerminationTest");
+            gpii.windows.killProcessByName(waitExe);
         }, function () {
             jqUnit.fail("Failed to detect process start.");
         });

--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -22,6 +22,7 @@ var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 var shelljs = require("shelljs");
 var path = require("path");
+var child_process = require("child_process");
 
 require("../processHandling.js");
 
@@ -109,15 +110,13 @@ jqUnit.asyncTest("Testing waiting for processes start and end", function () {
                 });
 
             // Tell the process to stop now.
-            gpii.windows.killProcessByName(waitExe);
+            child_process.execSync("waitfor /SI waitForProcessTerminationTest");
         }, function () {
             jqUnit.fail("Failed to detect process start.");
         });
 
     // Create the process, with a 5 second timeout
-    shelljs.exec(waitExePath + " waitForProcessTerminationTest /T 5 > nul", {
-        async: true
-    });
+    child_process.exec(waitExePath + " waitForProcessTerminationTest /T 5 > nul");
 });
 
 jqUnit.asyncTest("Testing Killing Processes", function () {
@@ -131,11 +130,9 @@ jqUnit.asyncTest("Testing Killing Processes", function () {
     // rest of the tests.
     var command =  waitExePath + " killProcessByNameTest /T 30";
     fluid.log("Executing " + command);
-    shelljs.exec(command, {
-        async: true
-    }, function (code, stdout, stderr) {
-        fluid.log("Exit code:", code);
-        jqUnit.assertEquals("Process should have terminated with code SIGKILL", 9, code);
+    child_process.exec(command, function (error, stdout, stderr) {
+        fluid.log("Exit code:", error.code);
+        jqUnit.assertEquals("Process should have terminated with code SIGKILL", 9, error.code);
         fluid.log("Program output:", stdout);
         fluid.log("Program stderr:", stderr);
         jqUnit.start();
@@ -159,11 +156,9 @@ jqUnit.asyncTest("Testing closeProcessByName", function () {
     var command =  exePath + " -window";
 
     fluid.log("Executing " + command);
-    var child = shelljs.exec(command, {
-        async: true
-    }, function (code) {
-        fluid.log("Exit code:", code);
-        jqUnit.assertEquals("Exit code", exitCode, code);
+    var child = child_process.exec(command, function (error) {
+        fluid.log("Exit code:", error.code);
+        jqUnit.assertEquals("Exit code", exitCode, error.code);
     });
 
     child.stdout.on("data", function (data) {
@@ -210,7 +205,5 @@ jqUnit.asyncTest("Testing closeProcessByName (window-less process)", function ()
 
     var command =  waitExePath + " closeProcessByNameTest /T 30";
     fluid.log("Executing " + command);
-    shelljs.exec(command, {
-        async: true
-    });
+    child_process.exec(command);
 });


### PR DESCRIPTION
This problem only happens when running the tests from within electron, more info at https://issues.gpii.net/browse/GPII-2302