### PR TITLE
GPII-2315: Magnifier doesn't apply subsequent settings

### DIFF
--- a/gpii/node_modules/registeredAT/registeredAT.js
+++ b/gpii/node_modules/registeredAT/registeredAT.js
@@ -54,6 +54,13 @@ gpii.windows.registeredAT = fluid.freezeRecursive({
     registeredATKey: {
         baseKey: "HKEY_LOCAL_MACHINE",
         path: "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility\\ATs"
+    },
+    /**
+     * The registry key where the settings to be transferred to the secure desktop are put.
+     */
+    settingsTransfer: {
+        baseKey: "HKEY_CURRENT_USER",
+        path: "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility\\ATConfig"
     }
 });
 
@@ -208,18 +215,29 @@ gpii.windows.startRegisteredAT = function (name, options) {
  */
 gpii.windows.stopRegisteredAT = function (name, options) {
     var exeName;
+
+    var atInfo = gpii.windows.getATInformation(name, ["ATExe", "CopySettingsToLockedDesktop"]);
+
     if (options && options.processName) {
         exeName = options.processName;
     } else {
-        // ATExe is the executable name, which is used to determine if the process is running.
-        var atInfo = gpii.windows.getATInformation(name, ["ATExe"]);
         if (options && options.atInfo) {
             atInfo = fluid.extend(atInfo, options.atInfo);
         }
         exeName = atInfo.ATExe;
     }
 
-    return gpii.windows.killProcessByName(exeName);
+    var promiseTogo = gpii.windows.killProcessByName(exeName);
+
+    // Remove the registry key that's used to transfer settings to the secure desktop, otherwise these settings
+    // will override any future settings. Really, the AT should do this when it closes, unfortunately it doesn't get
+    // closed cleanly so it is getting done here instead.GPII-2315.
+    if (atInfo.CopySettingsToLockedDesktop) {
+        var regPath = gpii.windows.registeredAT.settingsTransfer.path + "\\" + name;
+        gpii.windows.deleteRegistryKey(gpii.windows.registeredAT.settingsTransfer.baseKey, regPath);
+    }
+
+    return promiseTogo;
 };
 
 /**


### PR DESCRIPTION
Only the settings of the first instance of magnifier are applied. Subsequent instances continue to use those set first.

This fix performs some clean-up that magnifier would have done if it was closed nicely.