### PR TITLE
GPII-2338: Unable to log out if magnifier is closed manually

### DIFF
--- a/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
@@ -232,7 +232,10 @@ windows.deleteRegistryKey = function (baseKey, path) {
     var pathW = windows.ensureAlignment(windows.toWideChar(path).pointer);
     var base = windows.getBaseKey(baseKey);
     var code = advapi32.RegDeleteKeyW(base, pathW);
-    cr(code);
+    // Do not fail if delete was requested for nonexistent key
+    if (code !== windows.API_constants.returnCodes.FILE_NOT_FOUND) {
+        cr(code);
+    }
 };
 
 /**


### PR DESCRIPTION
Magnifier deletes a registry key before GPII does.

I just made it ignore the error if trying to delete a registry key that doesn't exist - as long as the key doesn't exist at the end, then does it matter wasn't there to being with?
