### PR TITLE
GPII-2339: Unable to log out if magnifier is closed manually

### DIFF
--- a/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
@@ -232,7 +232,10 @@ windows.deleteRegistryKey = function (baseKey, path) {
     var pathW = windows.ensureAlignment(windows.toWideChar(path).pointer);
     var base = windows.getBaseKey(baseKey);
     var code = advapi32.RegDeleteKeyW(base, pathW);
-    cr(code);
+    // Do not fail if delete was requested for nonexistent key
+    if (code !== windows.API_constants.returnCodes.FILE_NOT_FOUND) {
+        cr(code);
+    }
 };
 
 /**

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -214,6 +214,32 @@ gpii.tests.windows.registrySettingsHandler.enumerationTest = {
     }
 };
 
+gpii.tests.windows.registrySettingsHandler.deleteKeyTest = {
+    initPayload: {
+        "settings": {
+            "FollowMouse": 1,
+            "Invert": 0,
+            "Magnification": 255,
+            "Description": "GPII Magnifier"
+        },
+        "options": {
+            "hKey": "HKEY_CURRENT_USER",
+            "path": "Software\\GPIIMagnifier",
+            "dataTypes": {
+                "FollowMouse": "REG_DWORD",
+                "Invert":  "REG_DWORD",
+                "Magnification":  "REG_DWORD",
+                "Description": "REG_SZ"
+            }
+        },
+        "count": 4
+    },
+    expectedReturn: {
+        "statusCode": 404
+    }
+};
+
+
 jqUnit.test("Testing registrySettingsHandler.setImpl incl undefined value.value", function () {
     jqUnit.expect(1);
 
@@ -293,4 +319,36 @@ jqUnit.test("Enumerating registry key values", function () {
 
     // Clean up
     gpii.windows.deleteRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier");
+});
+
+jqUnit.test("Key deletion", function () {
+    var testData = gpii.tests.windows.registrySettingsHandler.deleteKeyTest;
+    var baseKey = testData.initPayload.options.hKey;
+    var path = testData.initPayload.options.path;
+
+    // Apply the data
+    gpii.windows.registrySettingsHandler.setImpl(testData.initPayload);
+
+    // Delete it
+    gpii.windows.deleteRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier");
+
+    // Enumerate the key
+    var result = gpii.windows.enumRegistryValues(baseKey, path);
+
+    // Check the result
+    jqUnit.assertDeepEq("Checking the return of enumRegistryValues", testData.expectedReturn, result);
+});
+
+jqUnit.test("Non-existing key deletion", function () {
+    jqUnit.expect(1);
+    try {
+        // Delete it
+        gpii.windows.deleteRegistryKey("HKEY_CURRENT_USER", "Software\\key-does-not-exist");
+    } catch (e) {
+        jqUnit.fail("Should not fail.");
+        throw e;
+    }
+
+    jqUnit.assert("Should succeed.");
+
 });


### PR DESCRIPTION
Magnifier deletes a registry key before GPII does.

I just made it ignore the error if trying to delete a registry key that doesn't exist - as long as the key doesn't exist at the end, then does it matter wasn't there to being with?