### PR TITLE
GPII-2402: Replaced "login" and "logout" with "proximityTrigger"

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/test/testAPI.json
+++ b/gpii/node_modules/spiSettingsHandler/test/testAPI.json
@@ -76,7 +76,7 @@
                     },                    
                     "settings": {
                         "MouseAcceleration": {
-                            "value": 3,
+                            "value": 0,
                             "path": "pvParam.2"
                         }
                     }
@@ -108,11 +108,11 @@
                     "settings": {
                         "MouseAcceleration": {
                             "oldValue": {
-                                "value": 2,
+                                "value": 1,
                                 "path": "pvParam.2"
                             },
                             "newValue": {
-                                "value": 3,
+                                "value": 0,
                                 "path": "pvParam.2"
                             }
                         }
@@ -156,7 +156,7 @@
                     },                    
                     "settings": {
                         "MouseAcceleration": {
-                            "value": 3,
+                            "value": 1,
                             "path": "pvParam.2"
                         }
                     }
@@ -178,7 +178,7 @@
                 }, {
                     "settings": {
                         "MouseAcceleration": {
-                            "value": 2,
+                            "value": 1,
                             "path": "pvParam.2"
                         }
                     }

--- a/gpii/node_modules/spiSettingsHandler/test/testMouse.json
+++ b/gpii/node_modules/spiSettingsHandler/test/testMouse.json
@@ -12,7 +12,7 @@
     
     "settings": {
         "MouseAcceleration": {
-            "value": 2,
+            "value": 0,
             "path": "pvParam.2"
         }
     }

--- a/listeners/GPII_RFIDListener/README.md
+++ b/listeners/GPII_RFIDListener/README.md
@@ -1,6 +1,6 @@
 # GPII RFIDListener
 
-Windows executable that listens out for NFC RFID tags and invokes URLs to trigger GPII user log on/off. It listens out for RFID tag events and reads the encoded tag data. The listener tracks the login state and generate login and logout events on the GPII RESTful API (e.g http://localhost:8081/user/bert/login).
+Windows executable that listens out for NFC RFID tags and invokes URLs to trigger GPII user log on/off. It listens out for RFID tag events and reads the encoded tag data. The listener does not track the login state and only informs GPII that a tag has been presented, via the GPII RESTful API (e.g http://localhost:8081/user/bert/proximityTriggered).
 
 See the [User listener](http://wiki.gpii.net/index.php/User_Listener) and [NFC](http://wiki.gpii.net/index.php/Using_the_NFC_Listener) pages on the GPII wikifor details of USB and NFC listening and how to encode user IDs.
 

--- a/listeners/GPII_RFIDListener/include/FlowManager.h
+++ b/listeners/GPII_RFIDListener/include/FlowManager.h
@@ -24,7 +24,13 @@
 #ifndef _FLOWMANAGER_H_
 #define _FLOWMANAGER_H_
 
-void FlowManagerLogin(const char * szToken);
+// Also emit a "proximityRemoved" request.
+//#define WANT_REMOVE_EVENT
+
+void FlowManagerCardOn(const char * szToken);
+#ifdef WANT_REMOVE_EVENT
+void FlowManagerCardOff(const char *szToken);
+#endif
 void FlowManagerLogout(const char * szToken);
 
 #endif // _FLOWMANAGER_H_

--- a/listeners/GPII_RFIDListener/include/FlowManager.h
+++ b/listeners/GPII_RFIDListener/include/FlowManager.h
@@ -31,6 +31,5 @@ void FlowManagerCardOn(const char * szToken);
 #ifdef WANT_REMOVE_EVENT
 void FlowManagerCardOff(const char *szToken);
 #endif
-void FlowManagerLogout(const char * szToken);
 
 #endif // _FLOWMANAGER_H_

--- a/listeners/GPII_RFIDListener/src/Diagnostic.cpp
+++ b/listeners/GPII_RFIDListener/src/Diagnostic.cpp
@@ -173,7 +173,7 @@ LRESULT CALLBACK _WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     switch (message)
     {
     //-----------------------------------------------------------
-    // Tray Icon Menu Commands to Show, Hide, Exit or Logout
+    // Tray Icon Menu Commands to Show, Hide, or Exit
     //-----------------------------------------------------------
     case WM_MYLOG:
     {

--- a/listeners/GPII_RFIDListener/src/FlowManager.cpp
+++ b/listeners/GPII_RFIDListener/src/FlowManager.cpp
@@ -41,8 +41,9 @@ extern void WINAPI OutputDebugString(
 // Flow Manager Constants
 //---------------------------------------------------------
 const char * const FLOW_MANAGER_URL = "http://localhost:8081/user";
-const char * const FLOW_LOGIN = "login";
 const char * const FLOW_LOGOUT = "logout";
+const char * const FLOW_CARDON = "proximityTriggered";
+const char * const FLOW_CARDOFF = "proximityRemoved";
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -88,16 +89,21 @@ static int _MakeCurlRequest(const char* szUser, const char* szAction)
     return 0;
 }
 
-
-
-void FlowManagerLogin(const char * szToken)
-{
-    _MakeCurlRequest(szToken, FLOW_LOGIN);
-}
-
-void FlowManagerLogout(const char * szToken) // FIXME should we keep state or can we have multiple concurrent logins?
+void FlowManagerLogout(const char *szToken)
 {
     _MakeCurlRequest(szToken, FLOW_LOGOUT);
 }
+
+void FlowManagerCardOn(const char *szToken)
+{
+    _MakeCurlRequest(szToken, FLOW_CARDON);
+}
+
+#ifdef WANT_REMOVE_EVENT
+void FlowManagerCardOff(const char *szToken)
+{
+    _MakeCurlRequest(szToken, FLOW_CARDOFF);
+}
+#endif
 
 // End of file

--- a/listeners/GPII_RFIDListener/src/FlowManager.cpp
+++ b/listeners/GPII_RFIDListener/src/FlowManager.cpp
@@ -41,7 +41,6 @@ extern void WINAPI OutputDebugString(
 // Flow Manager Constants
 //---------------------------------------------------------
 const char * const FLOW_MANAGER_URL = "http://localhost:8081/user";
-const char * const FLOW_LOGOUT = "logout";
 const char * const FLOW_CARDON = "proximityTriggered";
 const char * const FLOW_CARDOFF = "proximityRemoved";
 
@@ -51,11 +50,9 @@ const char * const FLOW_CARDOFF = "proximityRemoved";
 //
 //  PURPOSE:  Uses libcurl to make a HTTP GET request to a specified URL.
 //
-//  EXAMPLES:
+//  EXAMPLE:
 //
-//            http://localhost:8081/user/123/login
-//
-//            http://localhost:8081/user/123/logout
+//            http://localhost:8081/user/123/proximityTriggered
 //
 ///////////////////////////////////////////////////////////////////////////////
 static int _MakeCurlRequest(const char* szUser, const char* szAction)
@@ -87,11 +84,6 @@ static int _MakeCurlRequest(const char* szUser, const char* szAction)
         }
     }
     return 0;
-}
-
-void FlowManagerLogout(const char *szToken)
-{
-    _MakeCurlRequest(szToken, FLOW_LOGOUT);
 }
 
 void FlowManagerCardOn(const char *szToken)

--- a/listeners/GPII_RFIDListener/src/GPII_RFIDListener.cpp
+++ b/listeners/GPII_RFIDListener/src/GPII_RFIDListener.cpp
@@ -10,8 +10,8 @@
 // You may obtain a copy of the License at
 // https://github.com/gpii/windows/blob/master/LICENSE.txt
 //
-// The research leading to these results has received funding from 
-// the European Union's Seventh Framework Programme (FP7/2007-2013) 
+// The research leading to these results has received funding from
+// the European Union's Seventh Framework Programme (FP7/2007-2013)
 // under grant agreement no. 289016.
 //
 // The GPII RFID listener has the following features
@@ -87,9 +87,6 @@
 #include <Diagnostic.h>
 #include "WinSmartCard.h"
 
-// Display the logout menu item.
-//#define WANT_LOGOUT_MENU
-
 // MinGW doesn't define _countof in stdlib
 /* _countof helper */
 #if !defined (_countof)
@@ -108,7 +105,6 @@ const int    MY_SIZE_Y   = 100;
 #define      MY_SHOWSTATUS (WM_USER + 3)
 #define      MY_SHOWDIAG  (WM_USER + 4)
 #define      MY_EXIT      (WM_USER + 5)
-#define      MY_LOGOUT    (WM_USER + 6)
 #define      MY_TIMER     (WM_USER + 7)
 
 //---------------------------------------------------------
@@ -254,9 +250,6 @@ BOOL MyPopupMenu(HWND hWnd)
     InsertMenu(hPopupMenu, 0, MF_BYPOSITION | MF_STRING | fStatusChecked, MY_SHOWSTATUS, "View status window");
     const UINT fDiagChecked = (Diagnostic_IsShowing()) ? MF_CHECKED : 0;
     InsertMenu(hPopupMenu, 2, MF_BYPOSITION | MF_STRING | fDiagChecked, MY_SHOWDIAG, "View Diagnostic Window");
-#ifdef WANT_LOGOUT_MENU
-    InsertMenu(hPopupMenu, 3, MF_BYPOSITION | MF_STRING, MY_LOGOUT, "Logout");
-#endif
     InsertMenu(hPopupMenu, 4, MF_BYPOSITION | MF_STRING, MY_EXIT, "Exit");
     SetMenuItemBitmaps(hPopupMenu, MY_SHOWDIAG, MF_BYCOMMAND, NULL, NULL);
     SetForegroundWindow(hWnd);
@@ -395,7 +388,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         break;
 
     //-----------------------------------------------------------
-    // Tray Icon Menu Commands to Show, Hide, Exit or Logout
+    // Tray Icon Menu Commands to Show, Hide, or Exit
     //-----------------------------------------------------------
     case WM_COMMAND:
     {
@@ -409,23 +402,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         {
             DestroyWindow(hWnd);
         }
-#ifdef WANT_LOGOUT_MENU
-        else if (cmd == MY_LOGOUT)
-        {
-            if (m_nLogin)
-            {
-                wsprintf(m_szStatus,"%s","MENU LOGOUT");
-                FlowManagerLogout(m_szLatestUserID);
-                wsprintf(m_szLatestUserID,"%s","");
-                m_nLogin = 0;
-            }
-            else
-            {
-                wsprintf(m_szStatus,"%s","NO USER TO LOGOUT");
-            }
-            InvalidateRect(hWnd,NULL,TRUE);
-        }
-#endif
         if (cmd == MY_SHOWDIAG)
         {
             Diagnostic_Show(!Diagnostic_IsShowing());
@@ -490,10 +466,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     // Destroy the Window and Exit
     //-----------------------------------------------------------
     case WM_DESTROY:
-        if (m_nLogin)
-        {
-            FlowManagerLogout(m_szLatestUserID);
-        }
         KillTimer(hWnd,MY_TIMER);
         Diagnostic_CleanUp();
         PostQuitMessage(0);

--- a/listeners/GPII_RFIDListener/src/GPII_RFIDListener.rc
+++ b/listeners/GPII_RFIDListener/src/GPII_RFIDListener.rc
@@ -15,7 +15,7 @@
 //
 #include <windows.h>
 
-#define VER_PRODUCTVERSION          1,3,0
+#define VER_PRODUCTVERSION          1,4,0
 
 #define __str(a) #a
 #define _str(a) __str(a)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "ref": "1",
         "ref-struct": "1",
         "ref-array": "1.1.2",
-        "universal": "gpii/universal#b58d1859e4d53303a1fdc4d74640e0c43af345e5",
+        "universal": "gpii/universal#3159f2013d8752c403f6cee47b072c95a057e4a4",
         "nan": "amatas/nan#GPII-1929"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "ref": "1",
         "ref-struct": "1",
         "ref-array": "1.1.2",
-        "universal": "gpii/universal#3159f2013d8752c403f6cee47b072c95a057e4a4"
+        "universal": "gpii/universal#a9d56aa6dfc67e9430c9175826fe9d3e3bbc6c93"
     },
     "devDependencies": {
         "grunt": "1.0.1",


### PR DESCRIPTION
The fixes to work with https://github.com/GPII/universal/pull/513 which take the "logged in/out" state out of the RFID listener.

However, "logout" is still sent when the listener is closed (or the reader has gone).