### PR TITLE
GPII-2438: Get the path to the current version of wixtoolset

### DIFF
--- a/provisioning/Chocolatey.ps1
+++ b/provisioning/Chocolatey.ps1
@@ -21,10 +21,12 @@ Invoke-Command $chocolatey "install python2 -y"
 Add-Path $python2Path $true
 refreshenv
 
-# This seems weak. We should track bin path automatically and avoid version
-# declaration in the path.
-$wixSetupPath = "C:\Program Files (x86)\WiX Toolset v3.10\bin"
 Invoke-Command $chocolatey "install wixtoolset -y"
+refreshenv
+# The path to WIX can be found in $env:WIX env variable but looks like chocolatey's refreshenv
+# is not able to set such variable in this session. As a workaround, we ask the registry
+# for such environmental variable and set it so we can use it inside this powershell session.
+$wixSetupPath = Join-Path (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name WIX).WIX "bin"
 Add-Path $wixSetupPath $true
 refreshenv
 


### PR DESCRIPTION
This way, we avoid hardcoding the path to a particular version of Wix.