### PR TITLE
GPII-2483: Updated reference to universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "ref": "1",
         "ref-struct": "1",
         "ref-array": "1.1.2",
-        "universal": "gpii/universal#b58d1859e4d53303a1fdc4d74640e0c43af345e5",
+        "universal": "javihernandez/universal#GPII-2483",
         "nan": "amatas/nan#GPII-1929"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "ref": "1",
         "ref-struct": "1",
         "ref-array": "1.1.2",
-        "universal": "javihernandez/universal#GPII-2483"
+        "universal": "gpii/universal#72926ff9b401de5ead90738551f02830122e6150"
     },
     "devDependencies": {
         "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
         "ref": "1",
         "ref-struct": "1",
         "ref-array": "1.1.2",
-        "universal": "javihernandez/universal#GPII-2483",
-        "nan": "amatas/nan#GPII-1929"
+        "universal": "javihernandez/universal#GPII-2483"
     },
     "devDependencies": {
         "grunt": "1.0.1",


### PR DESCRIPTION
I'm also removing the nan dependency since it is no longer needed after node 6.8.0 was released.
