### PR TITLE
GPII-442:  Fixed typo in arguments list.

### DIFF
--- a/gpii/node_modules/processReporter/dotNetProcesses.csx
+++ b/gpii/node_modules/processReporter/dotNetProcesses.csx
@@ -10,8 +10,6 @@ You may obtain a copy of the License at
 https://github.com/gpii/universal/LICENSE.txt
 */
 
-#r "System.Management.dll"
-
 using System;
 using System.Text;
 using System.Collections;
@@ -34,103 +32,92 @@ public class Startup
 {
     public async Task<object> Invoke(dynamic input)
     {
-        Process[] processes = null;
-        Process aProcess;
+        ManagementObject[] processes = null;
+        object propValue;
         ProcessModule mainModule;
         ProcInfo aProcInfo;
         ArrayList result;
 
-        // Either get a list of processes with the given id or name, or a list
-        // of all processes.
-        aProcess = null;
-        bool foundProcess = false;
+        ManagementObjectCollection moc = new ManagementClass(new ManagementPath ("Win32_Process")).GetInstances();
+        processes = new ManagementObject[moc.Count];
+        moc.CopyTo(processes, 0);
+        result = new ArrayList();
+
+        // Check input for specified process id or command name.
         if (input != null) {
             if (input.GetType() == typeof(System.Int32)) {
-                try {
-                    aProcess = Process.GetProcessById(input);
-                    processes = new Process[1];
-                    processes[0] = aProcess;
-                    foundProcess = true;
+                ManagementObject aProcess = Array.Find(
+                    processes, p => Convert.ToInt32(p.GetPropertyValue("ProcessId")) == input
+                );
+                if (aProcess != null) {
+                    result.Add(makeProcInfo(aProcess));
                 }
-                catch (Exception e) {
-                    aProcess = null;
-                    foundProcess = false;
+            } else {
+                ManagementObject[] someProcesses = Array.FindAll(
+                    processes, p => p.GetPropertyValue("Name").ToString() == input
+                );
+                foreach (ManagementObject p in someProcesses) {
+                    result.Add(makeProcInfo(p));
                 }
-            }
-            else {
-                processes = Process.GetProcessesByName(input);
-                foundProcess = true;
             }
         }
-        if (!foundProcess) {
-            processes = Process.GetProcesses();
-        }
-
-        result = new ArrayList(processes.Length);
-        for (int i = 0; i < processes.Length; i++) {
-            aProcess = processes[i];
-            aProcInfo = new ProcInfo();
-            aProcInfo.pid = aProcess.Id;
-            aProcInfo.command = aProcess.ProcessName;
-
-            // Get the command line and its arguments.  Based on:
-            // https://stackoverflow.com/questions/2633628/can-i-get-command-line-arguments-of-other-processes-from-net-c
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher(
-                "SELECT CommandLine FROM Win32_Process WHERE ProcessId = " +
-                aProcess.Id
-            );
-            StringBuilder commandLine = new StringBuilder();
-            foreach (ManagementObject mo in searcher.Get()) {
-                commandLine.Append(mo["CommandLine"]);
-                commandLine.Append(" ");
+        // No process specified; gat all processes and their info
+        else {
+            foreach (ManagementObject p in processes) {
+                result.Add(makeProcInfo(p));
             }
-            aProcInfo.argv = makeArgv(commandLine.ToString());
-
-            // Get full path via the process's MainModule.  If that fails, use
-            // aProcInfo.argv[0].  If it succeeds, insure that argv[0] is the
-            // full path.
-            try {
-                mainModule = aProcess.MainModule;
-                aProcInfo.fullPath = mainModule.FileName;
-                aProcInfo.argv[0] = aProcInfo.fullPath;
-            }
-            catch (Exception e) {
-                mainModule = null;
-                if (aProcInfo.argv.Length > 0) {
-                    aProcInfo.fullPath = aProcInfo.argv[0];
-                }
-            }
-            // Use only the main thread's state (the first one).
-            // Also, map Windows thread states to Linux-y process states
-            // This may not be correct thing to do:  revisit.
-            ProcessThreadCollection threads = aProcess.Threads;
-            switch (aProcess.Threads[0].ThreadState) {
-                case ThreadState.Running:
-                case ThreadState.Wait:
-                    aProcInfo.state = "Running";
-                    break;
-
-                case ThreadState.Initialized:
-                case ThreadState.Ready:
-                case ThreadState.Standby:
-                case ThreadState.Transition:
-                    aProcInfo.state = "Sleeping";
-                    break;
-
-                case ThreadState.Terminated:
-                case ThreadState.Unknown:
-                    aProcInfo.state = "Zombie";
-                    break;
-            }
-            result.Add(aProcInfo);
         }
         return result.ToArray();
+    }
+
+    public static ProcInfo makeProcInfo(ManagementObject process) {
+        object propValue;
+
+        ProcInfo procInfo = new ProcInfo();
+        procInfo.command = process.GetPropertyValue("Name").ToString();
+        procInfo.pid = Convert.ToInt32(process.GetPropertyValue("ProcessId"));
+
+        propValue = process.GetPropertyValue("ExecutablePath");
+        if (propValue != null) {
+            procInfo.fullPath = propValue.ToString();
+        }
+        propValue = process.GetPropertyValue("CommandLine");
+        if (propValue != null) {
+            procInfo.argv = makeArgv(propValue.ToString());
+        }
+        // Should be able to get the state of the process using the
+        // "ExecutionState" property, but that is not implemented; see:
+        // http://maestriatech.com/wmi.php
+        //
+        // Use the Process's main thread's state (the first one).
+        // Also, map Windows thread states to Linux-y process states.
+        Process theProcess = Process.GetProcessById(procInfo.pid);
+        switch (theProcess.Threads[0].ThreadState) {
+            case ThreadState.Running:
+            case ThreadState.Wait:
+                procInfo.state = "Running";
+                break;
+
+            case ThreadState.Initialized:
+            case ThreadState.Ready:
+            case ThreadState.Standby:
+            case ThreadState.Transition:
+                procInfo.state = "Sleeping";
+                break;
+
+            case ThreadState.Terminated:
+            case ThreadState.Unknown:
+                procInfo.state = "Zombie";
+                break;
+        }
+        return procInfo;
     }
 
     public static String[] makeArgv(String commandLine)
     {
         List<String> arguments = new List<String>();
 
+        commandLine = commandLine + " ";
         for (int c = 0; c < commandLine.Length; c++) {
             // Handle quoted strings.
             if (commandLine[c] == '"') {

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -26,7 +26,7 @@ fluid.defaults("gpii.processes.windows", {
     invokers: {
         getPlatformProcesssList: {
             funcName: "gpii.processes.windows.getProcessList",
-            args: ["{arguments.0}"]
+            args: ["{arguments}.0"]
                    // process name or id, optional.
         }
     }

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -24,7 +24,7 @@ var dotNetProcesses = edge.func(path.join(__dirname, "dotNetProcesses.csx"));
 fluid.defaults("gpii.processes.windows", {
     gradeNames: ["gpii.processes"],
     invokers: {
-        getPlatformProcesssList: {
+        getPlatformProcessList: {
             funcName: "gpii.processes.windows.getProcessList",
             args: ["{arguments}.0"]
                    // process name or id, optional.

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -24,7 +24,7 @@ var dotNetProcesses = edge.func(path.join(__dirname, "dotNetProcesses.csx"));
 fluid.defaults("gpii.processes.windows", {
     gradeNames: ["gpii.processes"],
     invokers: {
-        getPlatformProcessList: {
+        getProcessList: {
             funcName: "gpii.processes.windows.getProcessList",
             args: ["{arguments}.0"]
                    // process name or id, optional.

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -24,7 +24,7 @@ var dotNetProcesses = edge.func(path.join(__dirname, "dotNetProcesses.csx"));
 fluid.defaults("gpii.processes.windows", {
     gradeNames: ["gpii.processes"],
     invokers: {
-        getPlaformProcesssList: {
+        getPlatformProcesssList: {
             funcName: "gpii.processes.windows.getProcessList",
             args: ["{arguments.0}"]
                    // process name or id, optional.

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -19,7 +19,11 @@ var path = require("path"),
     fluid = require("universal");
 
 var gpii = fluid.registerNamespace("gpii");
-var dotNetProcesses = edge.func(path.join(__dirname, "dotNetProcesses.csx"));
+
+var dotNetProcesses = edge.func({
+    source: path.join(__dirname, "dotNetProcesses.csx"),
+    references: ["System.Management.dll"]
+});
 
 fluid.defaults("gpii.processes.windows", {
     gradeNames: ["gpii.processes"],

--- a/gpii/node_modules/processReporter/test/processReporterModuleTests.js
+++ b/gpii/node_modules/processReporter/test/processReporterModuleTests.js
@@ -34,7 +34,7 @@ jqUnit.test("Running tests for Windows Process Reporter", function () {
 
     // This is running inside 'node' itself, so the uid matches.
     jqUnit.assertTrue("Checking run-status of process 'node'",
-                       gpii.processReporter.find("node"));
+                       gpii.processReporter.find("node.exe"));
 
     // Unlikely there is ever a process named "T6y7u8i9C".
     jqUnit.assertFalse("Checking run-status of process 'T6y7u8i9'",

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -39,7 +39,7 @@ jqUnit.module("Processes Bridge for Windows module");
 jqUnit.test(
     "Test getProceses('node')/findProcessByPid() with the nodejs process itself",
     function () {
-        var procInfos = processesBridge.getProcessList("node");
+        var procInfos = processesBridge.getProcessList("node.exe");
         jqUnit.assertNotEquals(
             "Listing all processes", 0, procInfos.length
         );
@@ -82,7 +82,7 @@ jqUnit.test(
     function () {
         var nodeProcInfo = processesBridge.findProcessByPid(process.pid);
         jqUnit.assertEquals("Node process 'name'",
-            path.parse(process.execPath).name, nodeProcInfo.command);
+            path.parse(process.execPath).base, nodeProcInfo.command);
 
         jqUnit.assertEquals("Node process 'pid'",
             process.pid, nodeProcInfo.pid);
@@ -102,9 +102,10 @@ jqUnit.test(
         // The order of process.argv and nodeProcInfo.argv is not
         // necessarily the same, nor are the number of arguments the same.
         // Only the first argument of the vectors match.
+        debugger;
         jqUnit.assertEquals("Node process argv[0]",
             path.basename(process.argv[0]),
-            path.basename(nodeProcInfo.argv[0])
+            path.basename(nodeProcInfo.argv[0]) + ".exe"
         );
     }
 );
@@ -112,23 +113,22 @@ jqUnit.test(
 jqUnit.test(
     "Test findProcessesByCmd()/findFirstProcessByCmd() with nodejs itself",
     function () {
-        var nodeProcInfos = processesBridge.findProcessesByCommand("node");
+        var nodeProcInfos = processesBridge.findProcessesByCommand("node.exe");
         jqUnit.assertNotEquals(
             "Getting all 'node' processes", 0, nodeProcInfos.length
         );
         nodeProcInfos.forEach(function (aProcInfo) {
             jqUnit.assertEquals(
-                "Node commmand name", "node", aProcInfo.command
+                "Node commmand name", "node.exe", aProcInfo.command
             );
         });
-        var procInfo = processesBridge.findFirstProcessByCommand("node");
+        var procInfo = processesBridge.findFirstProcessByCommand("node.exe");
         jqUnit.assertNotNull(
             "Looking for first 'node' processes", procInfo);
-        jqUnit.assertEquals("Node commmand name", "node", procInfo.command);
+        jqUnit.assertEquals("Node commmand name", "node.exe", procInfo.command);
     }
 );
 
-// Universal ?
 jqUnit.test(
     "Test initProcInfoNotRunning()",
     function () {
@@ -177,7 +177,7 @@ jqUnit.test(
 jqUnit.test(
     "Test updateProcInfo() against changing process",
     function () {
-        var notePad = spawn("notepad");
+        var notePad = spawn("notepad.exe");
         var notePadInfo = processesBridge.findProcessByPid(notePad.pid);
         jqUnit.assertNotNull("Search 'notepad' process", notePadInfo);
         jqUnit.assertTrue("Stop Notepad", notePad.kill("SIGKILL"));
@@ -192,14 +192,14 @@ jqUnit.test(
 jqUnit.test(
     "Test findSolutionsByCommands()",
     function () {
-        // Node is running. Add a running cat process. No such command as why.
-        var notePad = spawn("notepad");
-        var solutions = ["node", "notepad", "why"];
+        // Node is running. Add a running notepad process. No such command as why.
+        var notePad = spawn("notepad.exe");
+        var solutions = ["node.exe", "notepad.exe", "why.exe"];
         var procInfos = processesBridge.findSolutionsByCommands(solutions);
         jqUnit.assertTrue("Node and Notepad processes", procInfos.length >= 2);
         procInfos.forEach(function (item) {
-            var isNode = item.command === "node";
-            var isCat = item.command === "notepad";
+            var isNode = item.command === "node.exe";
+            var isCat = item.command === "notepad.exe";
             jqUnit.assertTrue("Process name node or notepad", isNode || isCat);
         });
         notePad.kill("SIGKILL");
@@ -209,7 +209,7 @@ jqUnit.test(
 jqUnit.test(
     "Test findSolutionsByPids()",
     function () {
-        // Node is running. Add a running cat process.
+        // Node is running. Add a running notepad process.
         var notePad = spawn("notepad");
         var pids = [process.pid, notePad.pid];
         var procInfos = processesBridge.findSolutionsByPids(pids);

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -88,7 +88,7 @@ jqUnit.test(
             process.pid, nodeProcInfo.pid);
 
         jqUnit.assertEquals("Node process 'argv' length'",
-            process.argv.length, nodeProcInfo.argv.length);
+            process.argv.length + process.execArgv.length, nodeProcInfo.argv.length);
 
         jqUnit.assertEquals("Node process status",
             "Running", nodeProcInfo.state);

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "dependencies": {
         "ffi": "2.0.0",
         "ref": "1.3.4",
-        "ref-struct": "1",
+        "ref-struct": "1.1.0",
         "ref-array": "1.1.2",
         "edge": "6.5.1",
-        "universal": "GPII/universal#0a26211506ed4258e451c1fc0df190170ec6ca35"
+        "universal": "gpii/universal#0a26211506ed4258e451c1fc0df190170ec6ca35"
     },
     "devDependencies": {
         "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "ref-struct": "1.1.0",
         "ref-array": "1.1.2",
         "edge": "6.5.1",
-        "universal": "gpii/universal#0a26211506ed4258e451c1fc0df190170ec6ca35"
+        "universal": "klown/universal#GPII-442"
     },
     "devDependencies": {
         "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "ref-struct": "1",
         "ref-array": "1.1.2",
         "edge": "6.5.1",
-        "universal": "klown/universal#GPII-442"
+        "universal": "GPII/universal#0a26211506ed4258e451c1fc0df190170ec6ca35"
     },
     "devDependencies": {
         "grunt": "1.0.1",


### PR DESCRIPTION
@amb26 @stegru As noted in [PR 47](https://github.com/GPII/universal/pull/547), this fixes a mistyped `{arguments}.0` in the windows processes bridge code (among other minor improvements).

Looking for a process by Id or name takes about 30 - 35 msec on my VM.
