### PR TITLE
GPII-2582: Fix failure in gpii-app tests

### DIFF
--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -27,9 +27,23 @@ require("../../WindowsUtilities/WindowsUtilities.js");
 var ffi = require("ffi");
 
 fluid.defaults("gpii.windowsMetrics", {
-    gradeNames: ["fluid.modelComponent"],
+    gradeNames: ["fluid.modelComponent", "fluid.contextAware"],
+    contextAwareness: {
+        platform: {
+            checks: {
+                test: {
+                    contextValue: "{gpii.contexts.test}",
+                    gradeNames: "gpii.windowsMetrics.test"
+                },
+                windows: {
+                    contextValue: "{gpii.contexts.windows}",
+                    gradeNames: "gpii.windowsMetrics.windows"
+                }
+            }
+        }
+    },
     listeners: {
-        "{eventLog}.events.onCreate": "{that}.events.onStartMetrics",
+        //"{eventLog}.events.onCreate": "{that}.events.onStartMetrics",
         "onDestroy.stopMetrics": "{that}.events.onStopMetrics",
         "onStartMetrics.application": "{that}.startApplicationMetrics",
         "onStopMetrics.application": "{that}.stopApplicationMetrics",
@@ -87,6 +101,16 @@ fluid.defaults("gpii.windowsMetrics", {
             }
         }
     }
+});
+
+fluid.defaults("gpii.windowsMetrics.windows", {
+    listeners: {
+        "{eventLog}.events.onCreate": "{that}.events.onStartMetrics"
+    }
+});
+
+// Don't auto-start the metrics capture when testing.
+fluid.defaults("gpii.windowsMetrics.test", {
 });
 
 fluid.defaults("gpii.eventLog.windows", {


### PR DESCRIPTION
This prevents the metrics capture starting while testing.