### PR TITLE
Fix processes bridge to run the same in PowerShell as in Command Prompt

### DIFF
--- a/gpii/node_modules/processReporter/dotNetProcesses.csx
+++ b/gpii/node_modules/processReporter/dotNetProcesses.csx
@@ -84,6 +84,14 @@ public class Startup
         propValue = process.GetPropertyValue("CommandLine");
         if (propValue != null) {
             procInfo.argv = makeArgv(propValue.ToString());
+
+            // In some cases the result is just the command, e.g., "Notepad".
+            // In others, it is the full path and may include the ".exe"
+            // extension.  Normalize it to always be the full path, if there is
+            // one.
+            if (procInfo.fullPath.Length > 0) {
+                procInfo.argv[0] = procInfo.fullPath;
+            }
         }
         // Should be able to get the state of the process using the
         // "ExecutionState" property, but that is not implemented; see:

--- a/gpii/node_modules/processReporter/dotNetProcesses.csx
+++ b/gpii/node_modules/processReporter/dotNetProcesses.csx
@@ -38,7 +38,7 @@ public class Startup
         ProcInfo aProcInfo;
         ArrayList result;
 
-        ManagementObjectCollection moc = new ManagementClass(new ManagementPath ("Win32_Process")).GetInstances();
+        ManagementObjectCollection moc = new ManagementClass(new ManagementPath("Win32_Process")).GetInstances();
         processes = new ManagementObject[moc.Count];
         moc.CopyTo(processes, 0);
         result = new ArrayList();
@@ -82,17 +82,10 @@ public class Startup
             procInfo.fullPath = propValue.ToString();
         }
         propValue = process.GetPropertyValue("CommandLine");
-        if (propValue != null) {
-            procInfo.argv = makeArgv(propValue.ToString());
-
-            // In some cases the result is just the command, e.g., "Notepad".
-            // In others, it is the full path and may include the ".exe"
-            // extension.  Normalize it to always be the full path, if there is
-            // one.
-            if (procInfo.fullPath.Length > 0) {
-                procInfo.argv[0] = procInfo.fullPath;
-            }
+        if (propValue == null) {
+            propValue = "";
         }
+        procInfo.argv = makeArgv(propValue.ToString(), procInfo.fullPath);
         // Should be able to get the state of the process using the
         // "ExecutionState" property, but that is not implemented; see:
         // http://maestriatech.com/wmi.php
@@ -121,7 +114,7 @@ public class Startup
         return procInfo;
     }
 
-    public static String[] makeArgv(String commandLine)
+    public static String[] makeArgv(String commandLine, String fullPath)
     {
         List<String> arguments = new List<String>();
 
@@ -145,6 +138,15 @@ public class Startup
                 arguments.Add(commandLine.Substring(firstChar, endStringIndex - firstChar));
                 c = endStringIndex;
             }
+        }
+
+        // In some cases the first argument is just the command, e.g., "Notepad".
+        // In others, it is the full path and may include the ".exe"
+        // extension.  Normalize it to always be the full path.
+        if (arguments.Count == 0) {
+            arguments.Add(fullPath);
+        } else {
+            arguments[0] = fullPath;
         }
         return arguments.ToArray();
     }

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -54,7 +54,7 @@ jqUnit.test(
 );
 
 jqUnit.test(
-    "Test getProceses()/findProcessByPid() with the nodejs process itself",
+    "Test getProceses()/findProcessByPid() with the 'process' object itself",
     function () {
         var procInfos = processesBridge.getProcessList();
         jqUnit.assertNotEquals(
@@ -79,7 +79,7 @@ jqUnit.test(
 );
 
 jqUnit.test(
-    "Test findProcessByPid() against nodejs's own process object.",
+    "Test findProcessByPid() against the 'process' object.",
     function () {
         var nodeProcInfo = processesBridge.findProcessByPid(process.pid);
         jqUnit.assertEquals("Node process 'name'",
@@ -95,7 +95,7 @@ jqUnit.test(
             "Running", nodeProcInfo.state);
 
         // The "fullPath" property is added by the process node add-on.
-        // It should match the full path to process.title.
+        // It should match the full path to process.execPath.
         jqUnit.assertEquals("Node process fullPath",
             process.execPath, nodeProcInfo.fullPath
         );
@@ -146,7 +146,7 @@ jqUnit.test(
 );
 
 jqUnit.test(
-    "Test isRunning() with nodejs itself, and nonexistent process",
+    "Test isRunning() with 'process' object itself, and nonexistent process",
     function () {
         var procInfo = processesBridge.findProcessByPid(process.pid);
         jqUnit.assertNotNull("Searching for 'node' process", procInfo);
@@ -166,7 +166,7 @@ jqUnit.test(
     "Test updateProcInfo() against non-changing process",
     function () {
         var procInfo = processesBridge.findProcessByPid(process.pid);
-        jqUnit.assertNotNull("Looking for 'node' processes", procInfo);
+        jqUnit.assertNotNull("Looking for process.pid processes", procInfo);
         var newProcInfo = processesBridge.updateProcInfo(procInfo);
         jqUnit.assertDeepEq(
             "Check change in process info", procInfo, newProcInfo
@@ -199,8 +199,8 @@ jqUnit.test(
         jqUnit.assertTrue("Node and Notepad processes", procInfos.length >= 2);
         procInfos.forEach(function (item) {
             var isNode = item.command === "node.exe";
-            var isCat = item.command === "notepad.exe";
-            jqUnit.assertTrue("Process name node or notepad", isNode || isCat);
+            var isNotePad = item.command === "notepad.exe";
+            jqUnit.assertTrue("Process name node or notepad", isNode || isNotePad);
         });
         notePad.kill("SIGKILL");
     }

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -102,7 +102,6 @@ jqUnit.test(
         // The order of process.argv and nodeProcInfo.argv is not
         // necessarily the same, nor are the number of arguments the same.
         // Only the first argument of the vectors match.
-        debugger;
         jqUnit.assertEquals("Node process argv[0]",
             path.basename(process.argv[0]),
             path.basename(nodeProcInfo.argv[0]) + ".exe"

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -104,7 +104,7 @@ jqUnit.test(
         // Only the first argument of the vectors match.
         jqUnit.assertEquals("Node process argv[0]",
             path.basename(process.argv[0]),
-            path.basename(nodeProcInfo.argv[0]) + ".exe"
+            path.basename(nodeProcInfo.argv[0])
         );
     }
 );

--- a/gpii/node_modules/processReporter/test/processesBridge_tests.js
+++ b/gpii/node_modules/processReporter/test/processesBridge_tests.js
@@ -37,9 +37,10 @@ var processesBridge = gpii.processes.windows();
 
 jqUnit.module("Processes Bridge for Windows module");
 jqUnit.test(
-    "Test getProceses('node')/findProcessByPid() with the nodejs process itself",
+    "Test getProceses('<command>')/findProcessByPid() using the 'process' object itself",
     function () {
-        var procInfos = processesBridge.getProcessList("node.exe");
+        var processCommand = path.parse(process.execPath).base;
+        var procInfos = processesBridge.getProcessList(processCommand);
         jqUnit.assertNotEquals(
             "Listing all processes", 0, procInfos.length
         );


### PR DESCRIPTION
@javihernandez, here's a pull request to fix the unit test in gpii-app. 

The problem: when run under PowerShell, the C# code returns slightly different information compared to when run under the older command prompt.  CI for the windows repo uses the command prompt for the unit tests (and they all pass).  Gpii-app, however, is launched via a PowerShell script, and the difference causes that one unit test to fail.  I've normalized the output of the C# code such that it should no longer matter.

I hope this does the trick.