### PR TITLE
GPII-2613 Process reporter tests failures

### DIFF
--- a/gpii/node_modules/processReporter/dotNetProcesses.csx
+++ b/gpii/node_modules/processReporter/dotNetProcesses.csx
@@ -24,7 +24,7 @@ public class ProcInfo
     public string command = "";
     public int pid = -1;
     public string fullPath = "";
-    public string[] argv;
+    public string commandLine = "";
     public string state = "";
 }
 
@@ -61,7 +61,7 @@ public class Startup
                 }
             }
         }
-        // No process specified; gat all processes and their info
+        // No process specified; get all processes and their info.
         else {
             foreach (ManagementObject p in processes) {
                 result.Add(makeProcInfo(p));
@@ -85,7 +85,8 @@ public class Startup
         if (propValue == null) {
             propValue = "";
         }
-        procInfo.argv = makeArgv(propValue.ToString(), procInfo.fullPath);
+        procInfo.commandLine = propValue.ToString();
+
         // Should be able to get the state of the process using the
         // "ExecutionState" property, but that is not implemented; see:
         // http://maestriatech.com/wmi.php
@@ -112,42 +113,5 @@ public class Startup
                 break;
         }
         return procInfo;
-    }
-
-    public static String[] makeArgv(String commandLine, String fullPath)
-    {
-        List<String> arguments = new List<String>();
-
-        commandLine = commandLine + " ";
-        for (int c = 0; c < commandLine.Length; c++) {
-            // Handle quoted strings.
-            if (commandLine[c] == '"') {
-                int firstChar = c + 1;
-                int endQuoteIndex = commandLine.IndexOf('"', firstChar);
-                arguments.Add(commandLine.Substring(firstChar, endQuoteIndex - firstChar));
-                c = endQuoteIndex;
-            }
-            // Skip spaces outside of quoted strings.
-            else if (commandLine[c] == ' ') {
-                continue;
-            }
-            // Handle non-quoted string.
-            else {
-                int firstChar = c;
-                int endStringIndex = commandLine.IndexOf(' ', firstChar);
-                arguments.Add(commandLine.Substring(firstChar, endStringIndex - firstChar));
-                c = endStringIndex;
-            }
-        }
-
-        // In some cases the first argument is just the command, e.g., "Notepad".
-        // In others, it is the full path and may include the ".exe"
-        // extension.  Normalize it to always be the full path.
-        if (arguments.Count == 0) {
-            arguments.Add(fullPath);
-        } else {
-            arguments[0] = fullPath;
-        }
-        return arguments.ToArray();
     }
 }

--- a/gpii/node_modules/processReporter/processesBridge.js
+++ b/gpii/node_modules/processReporter/processesBridge.js
@@ -18,6 +18,7 @@ var path = require("path"),
     // This conditional require is to run the electron version of edge.js
     // when this code runs on electron (gpii-app).
     edge = process.versions.electron ? require("electron-edge") : require("edge"),
+    stringArgv = require("string-argv"),
     fluid = require("universal");
 
 var gpii = fluid.registerNamespace("gpii");
@@ -47,5 +48,17 @@ fluid.defaults("gpii.processes.windows", {
  *                                        (string), or a process id (number).
  */
 gpii.processes.windows.getProcessList = function (processIdentifier) {
-    return dotNetProcesses(processIdentifier, true);
+    var procInfos = dotNetProcesses(processIdentifier, true);
+
+    // Loop to convert the command line to an argv[].
+    fluid.each(procInfos, function (aProcInfo) {
+        aProcInfo.argv = stringArgv(aProcInfo.commandLine);
+        delete aProcInfo.commandLine;
+
+        // In some cases the first argument is just the command, e.g., "Notepad".
+        // In others, it is the full path and may include the ".exe"
+        // extension.  Normalize it to always be the full path.
+        aProcInfo.argv[0] = aProcInfo.fullPath;
+    });
+    return procInfos;
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "ref-struct": "1.1.0",
         "ref-array": "1.1.2",
         "edge": "6.5.1",
+        "string-argv": "0.0.2",
         "universal": "gpii/universal#60daaf849ac8b774a6ce5ede34f82259253b067b"
     },
     "devDependencies": {


### PR DESCRIPTION
@javihernandez @amb26 @stegru Here's a fix.

I ended up testing the npm module `string-argv` using the problematic command line that Javi listed in the [GPII-2613](https://issues.gpii.net/browse/GPII-2613)'s description, and it had no problem.  I've removed the C# makeArgv() code, and moved the functionality to JavaScript, introducing a dependency on `string-argv`.

In the process (no pun intended) I noticed that getting the command name of the process and the full path to the executable was done independently of creating the argv[].  However, removing the argv[] has implications for the universal code, and given Sandra's timeline (this needs to work by Mon), this was the way I went.

Have a look, and let me know what you think.
