### PR TITLE
GPII-2751: Gibberish from the registry

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -542,7 +542,7 @@ windows.toWideChar = function (string) {
     buffer.writeInt16BE(0, chars * 2);  // add the null character at the end
     return {
         pointer: buffer,
-        length: chars * 2
+        length: chars * 2 + 2
     };
 };
 

--- a/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
@@ -212,7 +212,9 @@ windows.readRegistryKey = function (baseKey, path, subKey, type) {
         cr(code2);
         togo.bytes = dataLength.readInt32LE(0);
 
-        var valueHolder = new Buffer(togo.bytes);
+        // Add an extra 2 bytes to ensure the return is always null terminated (numeric values will ignore it).
+        var valueHolder = new Buffer(togo.bytes + 2);
+        valueHolder.fill(0);
         var code3 = advapi32.RegQueryValueExW(keyHolder.readUInt32LE(0), subKeyW, NULL, NULL, valueHolder, dataLength);
         cr(code3);
 
@@ -318,8 +320,9 @@ windows.enumRegistryValues = function (baseKey, path) {
 
             togo[value.name] = value;
 
-            // Get the data for the value.
-            var dataHolder = new Buffer(value.bytes);
+            // Add an extra 2 bytes to ensure the return is always null terminated (numeric values will ignore it).
+            var dataHolder = new Buffer(value.bytes + 2);
+            dataHolder.fill(0);
             var code3 = advapi32.RegQueryValueExW(keyHolder.readUInt32LE(0), nameHolder, NULL, typeHolder, dataHolder, dataSizeHolder);
             cr(code3);
 

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -216,7 +216,7 @@ gpii.tests.windows.registrySettingsHandler.enumerationTest = {
         },
         "ZeroLength": {
             "data": "",
-            "bytes": 0,
+            "bytes": 2,
             "name": "ZeroLength",
             "type": "REG_SZ"
         }

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -289,9 +289,9 @@ jqUnit.test("Reading and writing single registry keys", function () {
     for (var retry = 0; retry < 50; retry++) {
         var emptyString = "";
         gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", emptyString, "REG_SZ");
-        var value5 = gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", "REG_SZ");
-        jqUnit.assertEquals("Assert empty REG_SZ", 0, value5.value.length);
-        if (value5.value.length) {
+        var result = gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", "REG_SZ");
+        jqUnit.assertEquals("Assert empty REG_SZ", 0, result.value.length);
+        if (result.value.length !== 0) {
             // One fail is enough.
             break;
         }

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -173,7 +173,8 @@ gpii.tests.windows.registrySettingsHandler.enumerationTest = {
             "FollowMouse": 1,
             "Invert": 0,
             "Magnification": 255,
-            "Description": "GPII Magnifier"
+            "Description": "GPII Magnifier",
+            "ZeroLength": ""
         },
         "options": {
             "hKey": "HKEY_CURRENT_USER",
@@ -182,10 +183,11 @@ gpii.tests.windows.registrySettingsHandler.enumerationTest = {
                 "FollowMouse": "REG_DWORD",
                 "Invert":  "REG_DWORD",
                 "Magnification":  "REG_DWORD",
-                "Description": "REG_SZ"
+                "Description": "REG_SZ",
+                "ZeroLength": "REG_SZ"
             }
         },
-        "count": 4
+        "count": 5
     },
     expectedReturn: {
         "FollowMouse": {
@@ -210,6 +212,12 @@ gpii.tests.windows.registrySettingsHandler.enumerationTest = {
             "data": "GPII Magnifier",
             "bytes": 30,
             "name": "Description",
+            "type": "REG_SZ"
+        },
+        "ZeroLength": {
+            "data": "",
+            "bytes": 0,
+            "name": "ZeroLength",
             "type": "REG_SZ"
         }
     }
@@ -255,7 +263,7 @@ jqUnit.test("Testing registrySettingsHandler.setImpl incl undefined value.value"
 });
 
 jqUnit.test("Reading and writing single registry keys", function () {
-    jqUnit.expect(5);
+    jqUnit.expect(55);
 
     var dwordValue = 100;
     gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "Magnification", dwordValue, "REG_DWORD");
@@ -275,13 +283,26 @@ jqUnit.test("Reading and writing single registry keys", function () {
     var value4 = gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "Magnification", "REG_DWORD");
     jqUnit.assertDeepEq("Assert value not found after deleted", {statusCode: 404}, value4);
 
+    // Test zero-length values return an empty string (GPII-2751).
+    // The failure of this test also depends on the 2 bytes after the buffer being zero, so run it a few times to reduce
+    // the element of luck.
+    for (var retry = 0; retry < 50; retry++) {
+        var emptyString = "";
+        gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", emptyString, "REG_SZ");
+        var value5 = gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", "REG_SZ");
+        jqUnit.assertEquals("Assert empty REG_SZ", 0, value5.value.length);
+        if (value5.value.length) {
+            // One fail is enough.
+            break;
+        }
+    }
+
     // clean up after ourselves
     gpii.windows.deleteRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier");
 
     // test for GPII-1108 - deletion of subkey of nonexistent parent should be permitted
     gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "Magnification", undefined, "REG_DWORD");
     jqUnit.assert("Deletion of subkey of nonexistent parent should be valid noop");
-
 });
 
 

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -263,7 +263,7 @@ jqUnit.test("Testing registrySettingsHandler.setImpl incl undefined value.value"
 });
 
 jqUnit.test("Reading and writing single registry keys", function () {
-    jqUnit.expect(55);
+    jqUnit.expect(5);
 
     var dwordValue = 100;
     gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "Magnification", dwordValue, "REG_DWORD");
@@ -286,7 +286,9 @@ jqUnit.test("Reading and writing single registry keys", function () {
     // Test zero-length values return an empty string (GPII-2751).
     // The failure of this test also depends on the 2 bytes after the buffer being zero, so run it a few times to reduce
     // the element of luck.
-    for (var retry = 0; retry < 50; retry++) {
+    var tries = 500;
+    jqUnit.expect(tries);
+    for (var retry = 0; retry < tries; retry++) {
         var emptyString = "";
         gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", emptyString, "REG_SZ");
         var result = gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier", "ZeroTest", "REG_SZ");


### PR DESCRIPTION
Added null characters to values read and written to the registry.

See [GPII-2751](https://issues.gpii.net/browse/GPII-2751?focusedCommentId=29806&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-29806).
