### PR TITLE
NOJIRA: Fixed registryResolver test failure on the next Windows 10 release

### DIFF
--- a/gpii/node_modules/registryResolver/test/testRegistryResolver.js
+++ b/gpii/node_modules/registryResolver/test/testRegistryResolver.js
@@ -31,8 +31,8 @@ jqUnit.test("Test Boolean Registry Lookups", function () {
     jqUnit.expect(2);
 
     jqUnit.assertTrue("Testing a registry key that always exists.",
-        gpii.deviceReporter.registryKeyExists("HKEY_CURRENT_USER",
-            "Software\\Microsoft\\Command Processor", "CompletionChar", "REG_DWORD"));
+        gpii.deviceReporter.registryKeyExists("HKEY_LOCAL_MACHINE",
+            "Software\\Microsoft\\Windows NT\\CurrentVersion", "SystemRoot", "REG_DWORD"));
 
     jqUnit.assertFalse("Testing a registry key that does not exist.",
         gpii.deviceReporter.registryKeyExists("HKEY_CURRENT_USER",


### PR DESCRIPTION
The next release of Windows, "Windows 10 Spring Creators Update", will break a test where it expects a registry key to exist but it no longer does.

Now using `HKLM\Software\Microsoft\Windows NT\CurrentVersion@SystemRoot` as this is always written to at boot-time.

```
04:54:53.378:  gpii.deviceReporter.registryKeyExists:HKEY_CURRENT_USER Software\Microsoft\Command Processor CompletionChar REG_DWORD
04:54:53.395:  jq: FAIL: Module "Registry Resolver" Test name "Test Boolean Registry Lookups" - Message: Testing a registry key that always exists.
04:54:53.395:  jq: Source:     at pok (\\gpii-build\c\build\gpii-app\node_modules\infusion\tests\test-core\jqUnit\js\jqUnit.js:112:15)
    at Object.assertTrue (\\gpii-build\c\build\gpii-app\node_modules\infusion\tests\test-core\jqUnit\js\jqUnit.js:145:13)
    at Object.<anonymous> (\\gpii-build\c\build\gpii-app\node_modules\gpii-windows\gpii\node_modules\registryResolver\test\testRegistryResolver.js:33:12)
    at Test.run (\\gpii-build\c\build\gpii-app\node_modules\infusion\tests\lib\qunit\js\qunit.js:207:18)
    at \\gpii-build\c\build\gpii-app\node_modules\infusion\tests\lib\qunit\js\qunit.js:365:10
    at process (\\gpii-build\c\build\gpii-app\node_modules\infusion\tests\lib\qunit\js\qunit.js:1457:24)
    at Timeout._onTimeout (\\gpii-build\c\build\gpii-app\node_modules\infusion\tests\lib\qunit\js\qunit.js:483:5)
    at ontimeout (timers.js:469:11)
    at tryOnTimeout (timers.js:304:5)
    at Timer.listOnTimeout (timers.js:264:5)
```