### PR TITLE
GPII-3099: Made GPII "DPI Aware"

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -220,6 +220,17 @@ gpii.windows.advapi32 = new ffi.Library("advapi32", {
     ]
 });
 
+gpii.windows.shcore = new ffi.Library("Shcore", {
+    // https://msdn.microsoft.com/library/dn302122
+    "SetProcessDpiAwareness": [
+        t.HANDLE, [ t.UINT ]
+    ]
+});
+
+// Make the process aware of DPI scaling, so Windows doesn't lie about non-client metrics (and perhaps other things).
+// See GPII-3099.
+gpii.windows.shcore.SetProcessDpiAwareness(1);
+
 /**
  * Gets a function pointer for an EnumWindowsProc callback for EnumWindows.
  *


### PR DESCRIPTION
Calling [SetProcessDpiAwareness](https://msdn.microsoft.com/library/dn302122) so Windows doesn't lie about the non-client metrics.

