### PR TITLE
GPII-3140: Made enableRegisteredAT.set return a promise

### DIFF
--- a/gpii/node_modules/registeredAT/registeredAT.js
+++ b/gpii/node_modules/registeredAT/registeredAT.js
@@ -134,13 +134,16 @@ gpii.windows.enableRegisteredAT.queryProcessReporter = function (entry) {
 };
 
 gpii.windows.enableRegisteredAT.set = function (settingsArray) {
-    return gpii.settingsHandlers.transformPayload(settingsArray, function (entry) {
+    var promises = [];
+    var togo = gpii.settingsHandlers.transformPayload(settingsArray, function (entry) {
         var registryName = entry.options.registryName;
         var enable = entry.settings.running;
 
         // get current value:
         var oldValue = gpii.windows.enableRegisteredAT.queryProcessReporter(entry);
-        gpii.windows.enableRegisteredAT(registryName, enable, entry.options);
+
+        var p = gpii.windows.enableRegisteredAT(registryName, enable, entry.options);
+        promises.push(p);
 
         return {
             settings: {
@@ -151,6 +154,13 @@ gpii.windows.enableRegisteredAT.set = function (settingsArray) {
             }
         };
     });
+
+    // Resolve the return promise when the AT ones resolve.
+    var promiseTogo = fluid.promise();
+    fluid.promise.sequence(promises).then(function () {
+        promiseTogo.resolve(togo);
+    });
+    return promiseTogo;
 };
 
 gpii.windows.enableRegisteredAT.get = function (settingsArray) {


### PR DESCRIPTION
Fixes intermittent failures in the acceptance tests.

Like https://github.com/GPII/windows/pull/167#issuecomment-400005673
