### PR TITLE
GPII-3236: App Zoom

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -121,6 +121,10 @@ windows.user32 = ffi.Library("user32", {
     "EnumWindows": [
         t.BOOL, ["void*", t.HANDLE]
     ],
+    // https://msdn.microsoft.com/library/ms633494
+    "EnumChildWindows": [
+        t.BOOL, [t.HANDLE, "void*", t.HANDLE]
+    ],
     // https://msdn.microsoft.com/library/windows/desktop/ms633522
     "GetWindowThreadProcessId": [
         t.DWORD, [t.HANDLE, t.LPDWORD]
@@ -198,6 +202,46 @@ windows.user32 = ffi.Library("user32", {
     // https://msdn.microsoft.com/library/ms632682
     "DestroyWindow": [
         t.BOOL, [ t.HANDLE ]
+    ],
+    // https://msdn.microsoft.com/library/ms644989
+    "RegisterShellHookWindow": [
+        t.BOOL, [ t.HANDLE ]
+    ],
+    // https://msdn.microsoft.com/library/ms644947
+    "RegisterWindowMessageW": [
+        t.UINT, [ "char*" ]
+    ],
+    // https://msdn.microsoft.com/library/ms644950
+    "SendMessageW": [
+        "int", [t.HANDLE, t.UINT, t.UINT, "int" ]
+    ],
+    // https://msdn.microsoft.com/library/ms633519
+    "GetWindowRect": [
+        t.BOOL, [ t.HANDLE, t.PVOID ]
+    ],
+    // https://msdn.microsoft.com/library/ms646304
+    "keybd_event": [
+        "void", [ "char", "char", t.DWORD, t.ULONG_PTR ]
+    ],
+    // https://msdn.microsoft.com/library/ms646260
+    "mouse_event": [
+        "void", [ t.DWORD, t.DWORD, t.DWORD, t.DWORD, t.ULONG_PTR ]
+    ],
+    // https://msdn.microsoft.com/library/ms648394
+    "GetCursorPos": [
+        t.BOOL, [ t.PVOID ]
+    ],
+    // https://msdn.microsoft.com/library/ms648394
+    "SetCursorPos": [
+        t.BOOL, [ "int", "int" ]
+    ],
+    // https://msdn.microsoft.com/library/ms633582
+    "GetClassNameW": [
+        t.INT, [ t.HANDLE, "char*", t.INT ]
+    ],
+    // https://msdn.microsoft.com/library/ms646329
+    "VkKeyScanW": [
+        "short", [ t.TCHAR ]
     ]
 });
 
@@ -291,6 +335,8 @@ windows.API_constants = {
     TRUE:   1,
     // https://msdn.microsoft.com/library/windows/desktop/ms632641
     WM_QUIT: 0x12,
+    // https://msdn.microsoft.com/library/ms912654
+    WM_KEYDOWN: 0x100,
     // https://msdn.microsoft.com/library/ms646281
     WM_KEYUP: 0x101,
     // https://msdn.microsoft.com/library/ms645616
@@ -299,6 +345,9 @@ windows.API_constants = {
     WM_LBUTTONUP: 0x202,
     // https://msdn.microsoft.com/library/ms646243
     WM_RBUTTONUP: 0x205,
+    // https://docs.microsoft.com/windows/desktop/inputdev/wm-mousewheel
+    WM_MOUSEWHEEL: 0x20A,
+
     // https://msdn.microsoft.com/library/aa363480
     WM_DEVICECHANGE: 0x219,
 
@@ -518,6 +567,20 @@ windows.DEV_BROADCAST_VOLUME = new Struct([
     [t.DWORD, "flags"]
 ]);
 
+// https://msdn.microsoft.com/library/dd162897
+windows.RECT = new Struct([
+    [t.LONG, "left"],
+    [t.LONG, "top"],
+    [t.LONG, "right"],
+    [t.LONG, "bottom"]
+]);
+
+// https://msdn.microsoft.com/library/dd162805
+windows.POINT = new Struct([
+    [t.LONG, "x"],
+    [t.LONG, "y"]
+]);
+
 /**
  * Contains actions that can be used as the first argument of the SystemParametersInfo function.
  */
@@ -596,6 +659,33 @@ windows.flagConstants = {
     "MKF_RIGHTBUTTONSEL":  0x20000000
 
     // TODO Define additional flags used across various structures here.
+};
+
+/**
+ * The MAKELONG win32 macro. Combines two 16-bit numbers into a 32-bit number.
+ *
+ * https://msdn.microsoft.com/library/ms644990
+ */
+windows.makeLong = function (low, high) {
+    return (low & 0xffff) | ((high & 0xffff) << 16);
+};
+
+/**
+ * The LOWORD win32 macro. Gets the low 16-bit number from a 32-bit number.
+ *
+ * https://msdn.microsoft.com/library/ms632659
+ */
+windows.loWord = function (value) {
+    return value & 0xffff;
+};
+
+/**
+ * The HIWORD win32 macro. Gets the high 16-bit number from a 32-bit number.
+ *
+ * https://msdn.microsoft.com/library/ms632657
+ */
+windows.hiWord = function (value) {
+    return (value >> 16) & 0xffff;
 };
 
 /**
@@ -885,19 +975,34 @@ windows.bufferToArray = function (buffer, type) {
 };
 
 /**
- * Enumerates all top-level windows on the desktop, invoking the callback for each one.
+ * Enumerates all top-level windows on the desktop, or all child windows (and their descendants) of a given window,
+ * invoking the callback for each one.
  *
- * @param callback Called for each Window.
+ * @param {Number} hwndParent [optional] The handle of the window whose child windows are to be enumerated.
+ * @param callback Called for each Window, returning a value other than undefined to break the enumeration.
+ * @return {Mixed} The last return value of callback.
  */
-windows.enumerateWindows = function (callback) {
+windows.enumerateWindows = function (hwndParent, callback) {
+    if (!callback && typeof(hwndParent) === "function") {
+        callback = hwndParent;
+        hwndParent = null;
+    }
+
+    var result;
     // Suppress "no-unused-vars" - lparam argument is required for EnumWindowsProc.
     // eslint-disable-next-line no-unused-vars
     var proc = gpii.windows.EnumWindowsProc(function (hwnd, lparam) {
-        callback(hwnd);
-        return true;
+        result = callback(hwnd);
+        return result === undefined;
     });
 
-    gpii.windows.user32.EnumWindows(proc, 0);
+    if (hwndParent) {
+        gpii.windows.user32.EnumChildWindows(hwndParent, proc, 0);
+    } else {
+        gpii.windows.user32.EnumWindows(proc, 0);
+    }
+
+    return result;
 };
 
 /**
@@ -922,6 +1027,29 @@ windows.getWindowProcessId = function (hwnd) {
     var ptr = ref.alloc(windows.types.DWORD);
     windows.user32.GetWindowThreadProcessId(hwnd, ptr);
     return ptr.deref();
+};
+
+/**
+ * Returns a given window's rectangle.
+ *
+ * @param {Number} hwnd The window handle.
+ * @returns {Object} Contains the left, top, right, bottom, width, and height values of the window.
+ */
+windows.getWindowRect = function (hwnd) {
+    var rect = new windows.RECT();
+    var success = windows.user32.GetWindowRect(hwnd, rect.ref());
+    var result;
+    if (success) {
+        result = {
+            left: rect.left,
+            top: rect.top,
+            right: rect.right,
+            bottom: rect.bottom
+        };
+        result.width = result.right - result.left;
+        result.height = result.bottom - result.top;
+    }
+    return result;
 };
 
 /**

--- a/gpii/node_modules/gpii-appZoom/README.md
+++ b/gpii/node_modules/gpii-appZoom/README.md
@@ -1,0 +1,5 @@
+# App Zoom
+
+Sends a zoom in/out signal to the currently activated application window. The actual signal differs between
+applications, and it's usually a simulated key press or ctrl+mouse wheel.
+

--- a/gpii/node_modules/gpii-appZoom/index.js
+++ b/gpii/node_modules/gpii-appZoom/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+require("./src/appZoom.js");

--- a/gpii/node_modules/gpii-appZoom/src/appZoom.js
+++ b/gpii/node_modules/gpii-appZoom/src/appZoom.js
@@ -1,0 +1,358 @@
+/*
+ * Application Zoom
+ *
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("gpii-universal"),
+    path = require("path");
+
+var gpii = fluid.registerNamespace("gpii");
+var windows = fluid.registerNamespace("gpii.windows");
+fluid.registerNamespace("gpii.windows.appZoom");
+
+fluid.defaults("gpii.windows.appZoom", {
+    gradeNames: ["fluid.component"],
+    invokers: {
+        startMessages: "{gpii.windows.messages}.start({that})",
+        stopMessages: "{gpii.windows.messages}.stop({that})",
+        getMessageWindow: "{gpii.windows.messages}.getWindowHandle()",
+        windowActivated: {
+            funcName: "gpii.windows.appZoom.windowActivated",
+            args: ["{that}", "{arguments}.0"] // [hwnd]
+        },
+        getConfig: {
+            funcName: "gpii.windows.appZoom.getConfig",
+            args: ["{that}", "{arguments}.0"] // [WindowInfo]
+        },
+        sendZoom: {
+            funcName: "gpii.windows.appZoom.sendZoom",
+            args: ["{that}", "{arguments}.0"] // [direction]
+        }
+    },
+    events: {
+        // The current window has changed.
+        onApplicationActivated: null // [{that}, WindowInfo]
+    },
+    listeners: {
+        "onCreate": "gpii.windows.appZoom.start({that})",
+        "{gpii.windows.messages}.events.onMessage": {
+            funcName: "gpii.windows.appZoom.windowMessage",
+            // that, hwnd, msg, wParam, lParam
+            args: [ "{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2", "{arguments}.3" ]
+        }
+    },
+    members: {
+        // The message identifier for the shellhook notification.
+        WM_SHELLHOOKMESSAGE: null,
+        // The window that should receive the zoom.
+        currentWindow: null
+    },
+    configurations: {
+        ignored: {
+            ignore: true,
+            match: ["explorer.exe"]
+        },
+        generic: {
+            wheel: {}
+        },
+        wheel: {
+            // Just the wheel message (which includes the ctrl key)
+            match: ["chrome.exe"],
+            wheel: {}
+        },
+        wheelCtrl: {
+            // The wheel message, with simulated ctrl press.
+            match: ["mintty.exe", "firefox.exe", "notepad++.exe"],
+            ctrl: true,
+            wheel: true
+        },
+        key: {
+
+        },
+        word: {
+            match: ["winword.exe"],
+            wheel: {
+                delay: 500
+            },
+            ctrl: true,
+            childWindow: "_WwG"
+        },
+        edge: {
+            match: ["microsoftedgecp.exe"],
+            // The active window reported by the shell message is wrong.
+            getForegroundWindow: true,
+            childWindow: "Windows.UI.Core.CoreWindow",
+            ctrl: true,
+            wheel: {
+                delay: 500,
+                simulate: true
+            }
+        },
+        acrobat: {
+            match: ["acrord32.exe"],
+            //childWindow: "AVL_AVView",
+            ctrl: true,
+            key: {
+                decrease: "-",
+                increase: "="
+            }
+        }
+    }
+});
+
+/**
+ * Information about a window.
+ * @typedef {Object} WindowInfo
+ * @property {Number} hwnd The window handle.
+ * @property {Number} pid The process ID.
+ * @property {String} exe The executable name (lower-cased, without the directory)
+ *
+ */
+
+/**
+ * Information about a configuration.
+ *
+ * @typedef {Object} ZoomConfig
+ * @property {String} name Config name.
+ * @property {String[]} match The executable files (without the directory) to match against.
+ *
+ * @property {Object} wheel [optional] Use ctrl+mouse wheel.
+ * @property {Object} wheel.ctrl Explicitly hold the control key down.
+ *
+ * @property {Object} keys [optional] The keys to send to adjust the zoom level.
+ * @property {String} keys.decrease The key to send to reduce the zoom.
+ * @property {String} keys.increase The key to send to increase the zoom.
+ */
+
+/**
+ * Sends the zoom command to the current window.
+ * @param {Component} that The gpii.windows.appZoom component.
+ * @param {String} direction The direction to zoom, "decrease" "increase".
+ */
+windows.appZoom.sendZoom = function (that, direction) {
+
+    var window = that.currentWindow;
+    var config = window && window.config;
+
+    var increment = direction === "increase" ? 1 : -1;
+
+    if (increment < 0 && direction !== "decrease") {
+        fluid.fail("sendZoom: direction should be either 'decrease' or 'increase'");
+    }
+
+    console.log(config);
+
+    var hwnd = 0;
+    if (config.childWindow) {
+        // Send messages to a child window - find the child.
+        var classBuffer = Buffer.alloc(0xff);
+
+        hwnd = windows.enumerateWindows(window.hwnd, function (hwndChild) {
+            if (windows.user32.GetClassNameW(hwndChild, classBuffer, classBuffer.length)) {
+                var cls = windows.stringFromWideChar(classBuffer);
+                return cls === config.childWindow ? hwndChild : undefined;
+            }
+        });
+
+        if (!hwnd) {
+            fluid.log("appZoom: child window '" + config.childWindow + "' not found.");
+        }
+    }
+
+
+    if (!hwnd) {
+        hwnd = window.hwnd;
+    }
+
+    console.log("hwnd: ", hwnd.toString(16));
+
+    if (config.ctrl) {
+        var VK_CONTROL = 0x11;
+        // Even though the WM_MOUSEWHEEL message does provide the modifier key state, some applications will
+        // still use GetKeyState/GetAsyncKeyState. For this case, simulate the control key press.
+        windows.user32.keybd_event(VK_CONTROL, 0, 0, 0);
+
+        // Always release the control key.
+        setInterval(function () {
+            windows.user32.keybd_event(VK_CONTROL, 0, 2, 0);
+        }, config.wheel && config.wheel.delay || 10);
+    }
+
+    if (config.wheel) {
+        var MK_CONTROL = 0x8;
+        var WHEEL_DELTA = 120;
+        var MOUSEEVENTF_WHEEL = 0x800;
+
+
+        var rect = windows.getWindowRect(hwnd);
+
+        var sendWheel = function () {
+            // Say that the mouse cursor is in the middle of the window.
+            var x = rect.left + rect.width / 2;
+            var y = rect.top + rect.height / 2;
+            var distance = WHEEL_DELTA * increment;
+
+            if (config.wheel.simulate) {
+                // Move the cursor on the window and simulate wheel movement.
+                var point = new windows.POINT();
+                windows.user32.GetCursorPos(point.ref());
+                windows.user32.SetCursorPos(x, y);
+                windows.user32.mouse_event(MOUSEEVENTF_WHEEL, 0, 0, distance, 0);
+                // Put it back again.
+                windows.user32.SetCursorPos(point.x, point.y);
+            } else {
+                // Send the wheel message.
+                var lParam = windows.makeLong(x, y);
+                var wParam = windows.makeLong(MK_CONTROL, distance);
+                windows.user32.PostMessageW(hwnd, windows.API_constants.WM_MOUSEWHEEL, wParam, lParam);
+            }
+        };
+
+        if (rect) {
+            if (config.wheel.delay) {
+                setTimeout(sendWheel, config.wheel.delay);
+            } else {
+                sendWheel();
+            }
+        }
+
+    } else if (config.key) {
+        var key = config.key[direction];
+        if (key) {
+            var keyCode = parseInt(key);
+            if (!keyCode) {
+                keyCode = windows.user32.VkKeyScanW(key.charCodeAt(0)) & 0xff;
+            }
+            windows.user32.PostMessageW(hwnd, windows.API_constants.WM_KEYDOWN, keyCode, 1);
+            windows.user32.PostMessageW(hwnd, windows.API_constants.WM_KEYUP, keyCode, 1);
+        }
+    }
+
+};
+
+/**
+ * Gets some information about a given window.
+ * @param {Number} hwnd The window handle.
+ * @return {WindowInfo} Information about the window.
+ */
+windows.appZoom.getWindowInfo = function (hwnd) {
+    var pid = hwnd && windows.getWindowProcessId(hwnd);
+    var result;
+
+    if (pid) {
+        var processPath = windows.getProcessPath(pid);
+
+        result = {
+            hwnd: hwnd,
+            pid: pid,
+            exe: path.basename(processPath).toLowerCase()
+        };
+    }
+    return result;
+};
+
+/**
+ * Gets the zoom configuration that should be used for given window.
+ *
+ * @param {Component} that The gpii.windows.appZoom component.
+ * @param {WindowInfo} window The window.
+ * @return {ZoomConfig} The configuration.
+ */
+windows.appZoom.getConfig = function (that, window) {
+    if (typeof(window) === "number") {
+        window = that.getWindowInfo();
+    }
+
+    var config = fluid.find(that.options.configurations, function (config) {
+        return fluid.makeArray(config.match).indexOf(window.exe) >= 0 ? config : undefined;
+    });
+
+    return config || that.options.configurations.generic;
+};
+
+/**
+ * A window has been activated.
+ * @param {Component} that The gpii.windows.appZoom component.
+ * @param {Number} hwnd The handle to the activated window.
+ */
+windows.appZoom.windowActivated = function (that, hwnd) {
+    if (that.activeWindow !== hwnd) {
+        that.activeWindow = hwnd;
+        var window = windows.appZoom.getWindowInfo(hwnd);
+        console.log("active ", window);
+
+        // Get the configuration for the window.
+        if (window && (window.pid !== process.pid)) {
+
+            window.config = that.getConfig(window);
+            if (!window.config.ignore) {
+                that.currentWindow = window;
+
+                if (window.config.getForegroundWindow) {
+                    // Edge's edge case. The window reported by the notification isn't the right window.
+                    window.hwnd = windows.user32.GetForegroundWindow();
+                }
+            }
+        }
+
+        console.log("currentWindow", that.currentWindow);
+        if (that.currentWindow) {
+            that.events.onApplicationActivated.fire(that, that.currentWindow);
+            //setTimeout(that.sendZoom, 1000, "increase");
+        }
+    }
+};
+
+/**
+ * Called when an event has been received by the message window.
+ *
+ * Handles the WM_SHELLHOOKMESSAGE message.
+ *
+ * @param {Component} that The gpii.windows.appZoom component.
+ * @param {Number} hwnd The window handle of the message window.
+ * @param {Number} msg The message identifier.
+ * @param {Number} wParam Message specific data.
+ * @param {void*} lParam Additional message specific data.
+ */
+gpii.windows.appZoom.windowMessage = function (that, hwnd, msg, wParam, lParam) {
+    var HSHELL_WINDOWACTIVATED = 4;
+    var HSHELL_RUDEAPPACTIVATED = 0x8004;
+
+    if (msg === that.WM_SHELLHOOKMESSAGE) {
+        if (wParam === HSHELL_WINDOWACTIVATED || wParam === HSHELL_RUDEAPPACTIVATED) {
+            // Run the code in the next tick so this function can return soon, as it's a window procedure.
+            process.nextTick(that.windowActivated, lParam.address());
+        }
+    }
+};
+
+/**
+ * Start monitoring window activation.
+ *
+ * @param {Component} that The gpii.windows.appZoom component.
+ */
+windows.appZoom.start = function (that) {
+    // Get the "dynamic constant" value of the WM_SHELLHOOKMESSAGE message identifier.
+    that.WM_SHELLHOOKMESSAGE = windows.user32.RegisterWindowMessageW(windows.stringToWideChar("SHELLHOOK"));
+
+    that.startMessages();
+    // Tell Windows to send WM_SHELLHOOKMESSAGE.
+    gpii.windows.user32.RegisterShellHookWindow(that.getMessageWindow());
+};
+
+
+//gpii.windows.appZoom();

--- a/gpii/node_modules/gpii-appZoom/test/testAppZoom.js
+++ b/gpii/node_modules/gpii-appZoom/test/testAppZoom.js
@@ -1,0 +1,41 @@
+/*
+ * Tests for Application Zoom
+ *
+ * Copyright 2015 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("gpii-universal");
+
+var jqUnit = fluid.require("node-jqunit");
+var gpii = fluid.registerNamespace("gpii");
+
+fluid.require("%gpii-windows");
+
+require("../src/appZoom.js");
+
+fluid.registerNamespace("gpii.tests.windows.appZoom");
+
+var teardowns = [];
+jqUnit.module("gpii.tests.windows.appZoom", {
+    setup: function () {
+    },
+    teardown: function () {
+        while (teardowns.length) {
+            teardowns.pop()();
+        }
+    }
+});
+
+gpii.toString();

--- a/index.js
+++ b/index.js
@@ -42,5 +42,6 @@ require("./gpii/node_modules/processReporter");
 require("./gpii/node_modules/windowMessages");
 require("./gpii/node_modules/userListeners");
 require("./gpii/node_modules/systemSettingsHandler");
+require("./gpii/node_modules/gpii-appZoom");
 
 module.exports = fluid;


### PR DESCRIPTION
Got the application zoom working (needs a bit more work).

To use: Invoke the `sendZoom` method of the component with "increase" or "decrease", which will sent the required signal to the active application.

Applications known to work:
- Excel
- notepad++
- Chrome
- Firefox
- Adobe acrobat

Still needs a bit of work to get Word and Edge working good.
