### PR TITLE
GPII-3230: Made DPIScale relative to the recommended setting.

### DIFF
--- a/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
@@ -213,7 +213,7 @@ windows.display.setImpl = function (payload) {
     }
 
     var targetDpi = payload.settings["screen-dpi"];
-    if (targetDpi) {
+    if (Number.isInteger(targetDpi)) {
         var oldDpi = windows.display.getScreenDpi();
         windows.display.setScreenDpi(targetDpi);
         results["screen-dpi"] = { oldValue: oldDpi.configured, newValue: targetDpi };

--- a/gpii/node_modules/displaySettingsHandler/src/dpiWindows10.js
+++ b/gpii/node_modules/displaySettingsHandler/src/dpiWindows10.js
@@ -17,7 +17,7 @@
  *
  * struct DISPLAYCONFIG_SET_DPI {
  *   DISPLAYCONFIG_DEVICE_INFO_HEADER header; // https://msdn.microsoft.com/en-us/library/windows/hardware/ff553920.aspx
- *   UINT32 dpiIndex; // see below
+ *   INT32 dpiOffset; // see below
  * };
  *
  * The 'type' member of the header, which is used to identify the type of packet, is (uint) -4.
@@ -28,15 +28,18 @@
  *
  * struct DISPLAYCONFIG_GET_DPI {
  *   DISPLAYCONFIG_DEVICE_INFO_HEADER header; // https://msdn.microsoft.com/en-us/library/windows/hardware/ff553920.aspx
- *   UINT32 unknown;     // Comes back as zero - the meaning is unknown. It could be the recommended dpiIndex?
- *   UINT32 dpiIndex;    // see below
- *   UINT32 maxDpiIndex; // The maximum value of dpiIndex, determined by the screen resolution.
+ *   INT32 unknown;     // Comes back as zero - the meaning is unknown.
+ *   INT32 dpiOffset;    // see below
+ *   INT32 maxDpiOffset; // The maximum value of dpiOffset, determined by the screen resolution.
  * };
  *
  * The 'type' member of header is (uint) -3.
- * maxDpiIndex is the maximum DPI of the current resolution, dpiIndex can be higher but not the actual DPI.
- * The dpiIndex is an index of the following scales (% of 96 DPI):
+ * maxDpiOffset is the maximum DPI of the current resolution, dpiOffset can be higher but not the actual DPI.
+ *
+ * The dpiOffset is the number of values away from the display's recommended value, and can be negative. The values
+ * (which are a percentage of 96 DPI), are:
  *   [ 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450, 500 ]
+ * For example, if the recommended DPI is 175%, then a dpiOffset of 0 is 175, 2 is 225, and -1 is 150.
  */
 
 var ref = require("ref");
@@ -147,15 +150,15 @@ windows.DISPLAYCONFIG_SOURCE_DEVICE_NAME = new Struct([
 windows.DISPLAYCONFIG_GET_DPI = new Struct([
     [windows.DISPLAYCONFIG_DEVICE_INFO_HEADER, "header"],
     ["uint32", "unknown"],
-    ["uint32", "dpiIndex"],
-    ["uint32", "maxDpiIndex"]
+    ["int32", "dpiOffset"],
+    ["int32", "maxDpiOffset"]
 ], {packed: true});
 
 // This structure is not documented or defined in the SDK, but it's what control panel appears to use when adjusting
 // the DPI.
 windows.DISPLAYCONFIG_SET_DPI = new Struct([
     [windows.DISPLAYCONFIG_DEVICE_INFO_HEADER, "header"],
-    ["uint32", "dpiIndex"]
+    ["int32", "dpiOffset"]
 ]);
 
 /**
@@ -273,43 +276,13 @@ windows.display.getPrimaryMonitorName = function () {
 };
 
 /**
- * Get the dpiIndex from the given scale.
+ * Sets the DPI scale of the primary display, by specifying the number of values away from an from the recommended
+ * setting.
  *
- * The dpiIndex is an index of the following percentages:
- * [ 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450, 500 ]
- *
- * @param scale The scale.
- * @return {number} The dpiIndex.
+ * @param offset The offset from the recommended setting.
+ * @return {{configured, maximum, actual}} The newly configured, actual, and maximum DPI offsets (see getScreenDpi).
  */
-windows.display.getDpiIndex = function (scale) {
-    if (scale < 0) {
-        return 0;
-    } else if (scale < 2.75) {
-        return Math.max(0, Math.round((scale - 1) / 0.25));
-    } else {
-        return Math.max(0, Math.round(scale / 0.5) + 1);
-    }
-};
-
-/**
- * Get the scale from the given dpiIndex.
- *
- * @param dpiIndex The DPI index sent to/from the display driver.
- * @return {number} The DPI scale that the index relates to.
- */
-windows.display.getDpiValue = function (dpiIndex) {
-    var dpiValues = [ 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 3, 3.5, 4, 4.5, 5 ];
-    dpiIndex = Math.max(0, Math.min(dpiValues.length - 1, dpiIndex));
-    return dpiValues[dpiIndex];
-};
-
-/**
- * Sets the DPI scale of the primary display.
- *
- * @param scale The target DPI scale, where 1 = 100% (of 96).
- * @return {{configured, maximum, actual}} The newly configured, actual, and maximum DPI scale (see getScreenDpi).
- */
-windows.display.setScreenDpi = function (scale) {
+windows.display.setScreenDpi = function (offset) {
     // Only change the primary monitor, because that's what setScreenResolution does.
     var monitorName = windows.display.getPrimaryMonitorName();
     var adapter = windows.display.getAdapter(monitorName);
@@ -318,7 +291,7 @@ windows.display.setScreenDpi = function (scale) {
     setPacket.header.adapterId = adapter.adapterId;
     setPacket.header.id = adapter.sourceId;
 
-    setPacket.dpiIndex = windows.display.getDpiIndex(scale);
+    setPacket.dpiOffset = offset;
     var ret = user32.DisplayConfigSetDeviceInfo(setPacket.ref());
     windows.checkReturnCode(ret);
 
@@ -327,7 +300,9 @@ windows.display.setScreenDpi = function (scale) {
 };
 
 /**
- * Get the configured, maximum, and actual DPI scale of the primary display.
+ * Get the configured, maximum, and actual DPI values of the primary display.
+ *
+ * The value is the number of "notches" away from the recommended setting of the display.
  *
  * The configured scale is what DPI should be if the resolution is high enough, the maximum scale is the highest DPI
  * scale that the current screen resolution supports. The actual scale (what the user is looking at) is the configured
@@ -349,8 +324,8 @@ windows.display.getScreenDpi = function (adapter) {
     var ret = user32.DisplayConfigGetDeviceInfo(getPacket.ref());
     windows.checkReturnCode(ret);
 
-    var configured = windows.display.getDpiValue(getPacket.dpiIndex);
-    var maximum = windows.display.getDpiValue(getPacket.maxDpiIndex);
+    var configured = getPacket.dpiOffset;
+    var maximum = getPacket.maxDpiOffset;
     return {
         configured: configured,
         maximum: maximum,

--- a/gpii/node_modules/displaySettingsHandler/src/dpiWindows10.js
+++ b/gpii/node_modules/displaySettingsHandler/src/dpiWindows10.js
@@ -291,6 +291,12 @@ windows.display.setScreenDpi = function (offset) {
     setPacket.header.adapterId = adapter.adapterId;
     setPacket.header.id = adapter.sourceId;
 
+    if (offset < -3) {
+        // There isn't a lower limit, so add an artificial bottom cap. If the display supports lower settings then it
+        // would probably be unusable beyond this point.
+        offset = -3;
+    }
+
     setPacket.dpiOffset = offset;
     var ret = user32.DisplayConfigSetDeviceInfo(setPacket.ref());
     windows.checkReturnCode(ret);
@@ -307,6 +313,8 @@ windows.display.setScreenDpi = function (offset) {
  * The configured scale is what DPI should be if the resolution is high enough, the maximum scale is the highest DPI
  * scale that the current screen resolution supports. The actual scale (what the user is looking at) is the configured
  * scale, capped at the maximum.
+ *
+ * Strangely, if the actual scale is lower than the lowest setting, it doesn't get capped.
  *
  * @param {Object} [adapter]
  * @return {{configured, maximum, actual}} The configured, maximum, and actual DPI scale.

--- a/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
@@ -27,6 +27,15 @@ require("../src/displaySettingsHandler.js");
 gpii.tests.displaySettings.dpiTestDefs = fluid.freezeRecursive([
     {
         // 100%
+        input: 0,
+        expected: {
+            actual: 0,
+            configured: 0,
+            maximum: "$maximum"
+        }
+    },
+    {
+        // 125%
         input: 1,
         expected: {
             actual: 1,
@@ -35,11 +44,11 @@ gpii.tests.displaySettings.dpiTestDefs = fluid.freezeRecursive([
         }
     },
     {
-        // 125%
-        input: 1.25,
+        // < 100%
+        input: -1,
         expected: {
-            actual: 1.25,
-            configured: 1.25,
+            actual: 0,
+            configured: -1,
             maximum: "$maximum"
         }
     },
@@ -49,42 +58,6 @@ gpii.tests.displaySettings.dpiTestDefs = fluid.freezeRecursive([
         expected: {
             actual: "$maximum",
             configured: "$overMaximum",
-            maximum: "$maximum"
-        }
-    },
-    {
-        // 50% (not possible)
-        input: 0.5,
-        expected: {
-            actual: 1,
-            configured: 1,
-            maximum: "$maximum"
-        }
-    },
-    {
-        // 0% (not possible)
-        input: 0,
-        expected: {
-            actual: 1,
-            configured: 1,
-            maximum: "$maximum"
-        }
-    },
-    {
-        // < 0% (not possible)
-        input: -1,
-        expected: {
-            actual: 1,
-            configured: 1,
-            maximum: "$maximum"
-        }
-    },
-    {
-        // 120% (should round to 125%)
-        input: 1.2,
-        expected: {
-            actual: 1.25,
-            configured: 1.25,
             maximum: "$maximum"
         }
     }
@@ -210,6 +183,6 @@ jqUnit.test("Testing setScreenDpi ", function () {
         var testData = tests[index];
         var actual = gpii.windows.display.setScreenDpi(testData.input);
 
-        jqUnit.assertDeepEq("setScreenDpi " + (testData.input * 100) + "%", testData.expected, actual);
+        jqUnit.assertDeepEq("setScreenDpi " + testData.input, testData.expected, actual);
     }
 });

--- a/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
@@ -47,8 +47,17 @@ gpii.tests.displaySettings.dpiTestDefs = fluid.freezeRecursive([
         // < 100%
         input: -1,
         expected: {
-            actual: 0,
+            actual: -1,
             configured: -1,
+            maximum: "$maximum"
+        }
+    },
+    {
+        // very low
+        input: -10,
+        expected: {
+            actual: -3,
+            configured: -3,
             maximum: "$maximum"
         }
     },


### PR DESCRIPTION
Fixes the DPI setting so it works as expected with hidpi displays.

The DPIScale is now the offset from the recommended value.

Testing:
You'll need a display whose recommended DPI setting is above 100%. See https://issues.gpii.net/browse/GPII-3230 for how to do it on a VM. The `salem` preference set should make the scale 1 value above the recommended, and the Larger snap-sets (like `snapset_1b`) should make things larger. 