### PR TITLE
GPII-2844: Forcing explorer death.

### DIFF
--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -387,6 +387,10 @@ gpii.windows.stopExplorer = function () {
                         promise.resolve(session);
                     }
                 });
+                // It sometimes fails, so kill it manually after a few seconds.
+                windows.waitForProcessTermination(explorerPid, { timeout: 5000 }).then(null, function () {
+                    process.kill(explorerPid);
+                });
             }
         }
     } else {


### PR DESCRIPTION
Fixes the explorer restart problem with language.

The problem was, under some unknown circumstances, explorer didn't die - even though the taskbar had gone.
