### PR TITLE
NOJIRA: Restarting explorer manually if RmRestart fails.

### DIFF
--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -18,7 +18,8 @@
 "use strict";
 
 var fluid = require("gpii-universal");
-var ref = require("ref");
+var ref = require("ref"),
+    child_process = require("child_process");
 
 var gpii = fluid.registerNamespace("gpii");
 var windows = fluid.registerNamespace("gpii.windows");
@@ -387,6 +388,10 @@ gpii.windows.stopExplorer = function () {
                         promise.resolve(session);
                     }
                 });
+                // It sometimes fails, so kill it manually after a few seconds.
+                windows.waitForProcessTermination(explorerPid, { timeout: 5000 }).then(null, function () {
+                    process.kill(explorerPid);
+                });
             }
         }
     } else {
@@ -418,7 +423,9 @@ gpii.windows.restartExplorer = function () {
             // Re-start the explorer process.
             var result = rm.RmRestart(session, 0, ref.NULL);
             if (result) {
-                throw windows.win32error("RmRestart", result);
+                fluid.log(windows.win32errorText("RmRestart", result));
+                fluid.log("Failed to restart explorer, doing it manually");
+                child_process.exec("%SystemRoot%\\explorer.exe /LOADSAVEDWINDOWS");
             }
 
         } finally {


### PR DESCRIPTION
Fixes `15:53:07.541:  FATAL ERROR: Uncaught exception: win32 error: RmRestart return:352 win32:1314`