### PR TITLE
GPII-3371: Restoring cursor position back to the physical position before resolution/DPI change.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -267,6 +267,10 @@ windows.user32 = ffi.Library("user32", {
     // https://msdn.microsoft.com/library/ms633499
     "FindWindowW": [
         gpii.windows.types.HANDLE, ["char*", "char*"]
+    ],
+    // https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-getsystemmetrics
+    "GetSystemMetrics": [
+        "int", ["int"]
     ]
 });
 
@@ -467,7 +471,11 @@ windows.API_constants = {
     // https://msdn.microsoft.com/en-us/library/windows/hardware/ff554003.aspx
     DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED: 11,
     DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EMBEDDED: 13,
-    DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL: 0x80000000
+    DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL: 0x80000000,
+
+    // https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-getsystemmetrics
+    SM_CXSCREEN: 0,
+    SM_CYSCREEN: 1
 };
 
 fluid.each(windows.API_constants.returnCodesLookup, function (value, key) {

--- a/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js
@@ -193,8 +193,27 @@ windows.display.setScreenResolution = function (newRes) {
     }
 };
 
+/**
+ * Gets the size of the desktop in logical pixels, taking the current DPI setting into consideration.
+ * This is different to the screen resolution, which counts the physical pixels.
+ *
+ * @return {Object} width and height of the desktop.
+ */
+windows.display.getDesktopSize = function () {
+    return {
+        width: windows.user32.GetSystemMetrics(windows.API_constants.SM_CXSCREEN),
+        height: windows.user32.GetSystemMetrics(windows.API_constants.SM_CYSCREEN)
+    };
+};
+
 windows.display.setImpl = function (payload) {
     var results = {};
+
+    // Changing the screen resolution or DPI moves the mouse pointer to the centre of the screen, so get the current
+    // position and restore it after the setting change.
+    var cursorPos = new windows.POINT();
+    windows.user32.GetCursorPos(cursorPos.ref());
+    var origSize = windows.display.getDesktopSize();
 
     var targetRes = payload.settings["screen-resolution"];
     if (targetRes) {
@@ -220,6 +239,14 @@ windows.display.setImpl = function (payload) {
     }
 
     fluid.log("display settings handler SET returning results ", results);
+
+    // Restore the mouse position, taking into account the change in screen size, so it is back to the previous physical
+    // position.
+    var newSize = windows.display.getDesktopSize();
+    var x = cursorPos.x * (newSize.width / origSize.width);
+    var y = cursorPos.y * (newSize.height / origSize.height);
+    windows.user32.SetCursorPos(x, y);
+
     return results;
 };
 


### PR DESCRIPTION
When changing the DPI scale or screen resolution, the cursor is moved to the centre of the screen (this does not happen in a virtual machine, because the host owns the pointer).

(M3: https://docs.google.com/document/d/1NODvtQA6YKRdIsIDSLP-gqcnN6nTkxg8cqlPoNCGTDQ/edit)

This fix moves the mouse cursor back to the physical position before the screen change. That is, if you put your finger on the mouse pointer before changing the DPI/resolution, the pointer should remain under your finger (if your finger moves, there may be medication to prevent this).

**How to test**

* If running in a VM, uncheck *Mouse integration* from the *Input* menu (after making sure you know the key used to release the mouse - usually right ctrl). This is to allow the guest to move the mouse pointer.
* For testing the resolution, enable *Scaled mode* from the *View* menu (`Host`+`C`) in order to simulate a physical screen that doesn't change its size.

`elmer` changes the resolution, `salem` does the scale (currently broken: https://github.com/GPII/universal/pull/643).

