### PR TITLE
GPII-3349: Metrics improvements

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -462,6 +462,10 @@ windows.API_constants = {
     LLKHF_UP:        0x80,
     LLMHF_INJECTED:  0x01,
 
+    // https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-registershellhookwindow
+    HSHELL_WINDOWACTIVATED: 4,
+    HSHELL_RUDEAPPACTIVATED: 0x8004,
+
     // https://msdn.microsoft.com/library/ms646306
     MAPVK_VK_TO_CHAR: 2,
 

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -267,6 +267,10 @@ windows.user32 = ffi.Library("user32", {
     // https://msdn.microsoft.com/library/ms633499
     "FindWindowW": [
         gpii.windows.types.HANDLE, ["char*", "char*"]
+    ],
+    // https://msdn.microsoft.com/library/ms646301
+    "GetKeyState": [
+        "short", ["int"]
     ]
 });
 
@@ -373,6 +377,8 @@ windows.API_constants = {
     WM_KEYDOWN: 0x100,
     // https://msdn.microsoft.com/library/ms646281
     WM_KEYUP: 0x101,
+    // https://docs.microsoft.com/windows/desktop/inputdev/wm-syskeyup
+    WM_SYSKEYUP: 0x105,
     // https://msdn.microsoft.com/library/ms645616
     WM_MOUSEMOVE: 0x200,
     // https://msdn.microsoft.com/library/ms645608
@@ -399,7 +405,9 @@ windows.API_constants = {
         VK_BACK: 0x08,
         VK_TAB: 0x09,
         VK_RETURN: 0x0D,
+        VK_SHIFT: 0x10,
         VK_CONTROL: 0x11,
+        VK_MENU: 0x12, // alt key
         VK_ESCAPE: 0x1B,
         VK_SPACE: 0x20,
         VK_PAGEUP: 0x21, // VK_PRIOR

--- a/gpii/node_modules/windowsMetrics/README.md
+++ b/gpii/node_modules/windowsMetrics/README.md
@@ -33,7 +33,7 @@ Example:
 
 ### System Information
 
-On start up, CPU, memory, and Windows version is recorded.
+On start up, CPU, memory, display and Windows version is recorded.
 
 Example:
 ```json
@@ -45,6 +45,8 @@ Example:
         "cpu": "Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz",
         "cores": 2,
         "memory": "2.0",
+        "resolution": "1280x951",
+        "scale": "1.25",
         "osRelease": "10.0.17134",
         "osEdition": "Windows 10 Enterprise Evaluation",
         "osBits": "64",

--- a/gpii/node_modules/windowsMetrics/README.md
+++ b/gpii/node_modules/windowsMetrics/README.md
@@ -1,0 +1,187 @@
+# GPII Windows Metrics
+
+This modules provides the ability to capture certain ways in which the system is being used. The data is written to a
+log file and uploaded to a log server via an external process, Filebeat.
+
+The main purpose is to be able to record the impact that GPII has on how the user uses their computer. See the
+*Automatic Data Collected and Rationale* document for further information.
+
+No personally identifiable data is captured.
+
+## Metrics
+
+The following metrics are captured:
+
+### GPII Versions
+
+The version of the gpii-windows, gpii-universal, gpii-app, and windowsMetrics modules are logged on startup.
+
+Example:
+```json
+{
+    "module": "metrics",
+    "event": "version",
+    "level": "INFO",
+    "data": {
+        "windowsMetrics": "0.3.0",
+        "gpii-app": "0.3.0-dev.20180315T174453Z.02de41c",
+        "gpii-windows": "0.3.0-dev.20180315T174453Z.02de41c",
+        "gpii-universal": "0.3.0-dev.20180905T001251Z.a9b24952"
+    }
+}
+```
+
+### System Information
+
+On start up, CPU, memory, and Windows version is recorded.
+
+Example:
+```json
+{
+    "module": "metrics",
+    "event": "system-info",
+    "level": "INFO",
+    "data": {
+        "cpu": "Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz",
+        "cores": 2,
+        "memory": "2.0",
+        "osRelease": "10.0.17134",
+        "osEdition": "Windows 10 Enterprise Evaluation",
+        "osBits": "64",
+        "systemMfr": "innotek GmbH",
+        "systemName": "VirtualBox"
+    }
+}
+```
+
+### Window Activation
+
+When a window has been activated. The `window` field identifies the window, to determine if a different window of the
+same process has been activated. 
+
+Example:
+```json
+{
+    "module": "metrics",
+    "event": "app-active",
+    "level": "INFO",
+    "data": {
+        "exe": "C:\\Windows\\explorer.exe",
+        "window": "41k-494w"
+    }
+}
+```
+
+### Application launch
+
+An application launch is logged when a window is first activated.
+
+Example:
+```json
+{
+    "module": "metrics",
+    "event": "app-launch",
+    "level": "INFO",
+    "data": {
+        "exe": "C:\\Windows\\explorer.exe"
+    }
+}
+```
+
+### Inactivity
+
+When the user is not using the computer.
+
+Example:
+```json
+{
+    "module": "metrics",
+    "event": "inactive-begin",
+    "level": "INFO"
+}
+```
+
+And when the usage is resumed.
+
+```json
+{
+    "module": "metrics",
+    "event": "inactive-stop",
+    "level": "INFO",
+    "data": {
+        "duration": 42
+    }
+}
+```
+
+### Typing
+
+When a key is pressed, any modifier keys (`CTRL`, `ALT`, or `SHIFT`) and number of milliseconds since the last key is
+logged.
+
+No printable keys are recorded.
+
+```json
+{
+    "module": "metrics",
+    "event": "key-time",
+    "level": "INFO",
+    "data": {
+        "keyTime": 260,
+        "modifierKeys": [
+            "SHIFT"
+        ]
+    }
+}
+```
+
+Also logged is the typing rate and corrections of a typing session.
+
+```json
+{
+    "module": "metrics",
+    "event": "typing-session",
+    "level": "INFO",
+    "data": {
+        "duration": 60000,
+        "count": 3,
+        "corrections": 0,
+        "rate": 3
+    }
+}
+```
+
+### Mouse usage
+
+Mouse clicks and wheel scrolls are recorded, along with the total distance travelled between clicks.
+
+The location of the click is not recorded.
+
+```json
+{
+    "module": "metrics",
+    "event": "mouse",
+    "level": "INFO",
+    "data": {
+        "button": 1,
+        "distance": 482
+    }
+}
+```
+
+For mouse wheels, the number of 'ticks' in the sample is captured (the scroll speed).
+
+```json
+{
+    "module": "metrics",
+    "event": "mouse",
+    "level": "INFO",
+    "data": {
+        "wheel": -1,
+        "modifierKeys": [
+            "CONTROL"
+        ]
+    }
+}
+```
+

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -24,6 +24,7 @@ var fluid = require("gpii-universal");
 
 var gpii = fluid.registerNamespace("gpii"),
     windows = fluid.registerNamespace("gpii.windows");
+fluid.registerNamespace("gpii.windows.metrics");
 
 var processesBridge = gpii.processes.windows();
 
@@ -53,7 +54,7 @@ fluid.defaults("gpii.windowsMetrics", {
         "onStartMetrics.input": "{that}.startInputMetrics",
         "onStopMetrics.input": "{that}.stopInputMetrics",
         "{gpii.windows.messages}.events.onMessage": {
-            funcName: "gpii.windows.metricsWindowMessage",
+            funcName: "gpii.windows.metrics.windowMessage",
             // that, hwnd, msg, wParam, lParam
             args: [ "{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2", "{arguments}.3" ]
         }
@@ -64,23 +65,23 @@ fluid.defaults("gpii.windowsMetrics", {
             args: ["metrics", "{arguments}.0", "{arguments}.1"]
         },
         startApplicationMetrics: {
-            funcName: "gpii.windows.startApplicationMetrics",
+            funcName: "gpii.windows.metrics.startApplicationMetrics",
             args: ["{that}"]
         },
         stopApplicationMetrics: {
-            funcName: "gpii.windows.stopApplicationMetrics",
+            funcName: "gpii.windows.metrics.stopApplicationMetrics",
             args: ["{that}"]
         },
         startInputMetrics: {
-            funcName: "gpii.windows.startInputMetrics",
+            funcName: "gpii.windows.metrics.startInputMetrics",
             args: ["{that}"]
         },
         stopInputMetrics: {
-            funcName: "gpii.windows.stopInputMetrics",
+            funcName: "gpii.windows.metrics.stopInputMetrics",
             args: ["{that}"]
         },
         windowActivated: {
-            funcName: "gpii.windows.metricsWindowActivated",
+            funcName: "gpii.windows.metrics.windowActivated",
             args: ["{that}", "{arguments}.0"] // window handle (hwnd)
         },
         startMessages: "{gpii.windows.messages}.start({that})",
@@ -155,7 +156,7 @@ windows.getMachineID = function () {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.checkNewApplication = function (that) {
+windows.metrics.checkNewApplication = function (that) {
     var runningApplications = that.state.application.runningApplications;
     var pid = that.state.application.currentProcess.pid;
     var exePath = that.state.application.currentProcess.exe;
@@ -195,7 +196,7 @@ windows.checkNewApplication = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.startApplicationMetrics = function (that) {
+windows.metrics.startApplicationMetrics = function (that) {
     that.state.application = fluid.copy(that.options.initialState.application);
     that.state.application.active = true;
     that.state.application.runningApplications = {
@@ -216,11 +217,11 @@ windows.startApplicationMetrics = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.stopApplicationMetrics = function (that) {
+windows.metrics.stopApplicationMetrics = function (that) {
     that.stopMessages();
     that.state.application.active = false;
     // Log the currently active window as though it was de-activated.
-    windows.logAppActivate(that);
+    windows.metrics.logAppActivate(that);
 };
 
 /**
@@ -229,7 +230,7 @@ windows.stopApplicationMetrics = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.logAppActivate = function (that) {
+windows.metrics.logAppActivate = function (that) {
     if (that.state.application.currentProcess) {
         var data = {
             exe: that.state.application.currentProcess.exe,
@@ -251,7 +252,7 @@ windows.logAppActivate = function (that) {
  * @param {Number} wParam Message specific data.
  * #param {Object} lParam Additional message specific data (passed, but not used).
  */
-windows.metricsWindowMessage = function (that, hwnd, msg, wParam) {
+windows.metrics.windowMessage = function (that, hwnd, msg, wParam) {
 
     if (msg === that.WM_SHELLHOOKMESSAGE) {
         if (wParam === windows.API_constants.HSHELL_WINDOWACTIVATED ||
@@ -266,7 +267,7 @@ windows.metricsWindowMessage = function (that, hwnd, msg, wParam) {
  * Called when a window has been activated.
  * @param {Component} that The gpii.windowsMetrics component.
  */
-windows.metricsWindowActivated = function (that) {
+windows.metrics.windowActivated = function (that) {
     var state = that.state.application;
 
     // Even though the handle to the active window is passed via WM_SHELLHOOKMESSAGE, it's been known to lie (with UWP
@@ -292,9 +293,9 @@ windows.metricsWindowActivated = function (that) {
 
         // Also perform the "application launch" metric here. A process having its window activated implies it's
         // been launched.
-        windows.checkNewApplication(that);
+        windows.metrics.checkNewApplication(that);
 
-        windows.logAppActivate(that);
+        windows.metrics.logAppActivate(that);
     }
 };
 
@@ -315,7 +316,7 @@ windows.metricsWindowActivated = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.startInputMetrics = function (that) {
+windows.metrics.startInputMetrics = function (that) {
     var debugMetrics = false;
     if (process.env.GPII_DEBUG_METRICS) {
         // Enable the input metrics by polling for messages.
@@ -323,7 +324,7 @@ windows.startInputMetrics = function (that) {
         gpii.windows.messages.messagePumpDelay = 1;
     }
 
-    windows.stopInputMetrics(that);
+    windows.metrics.stopInputMetrics(that);
 
     that.state.input = fluid.copy(that.options.initialState.input);
 
@@ -333,14 +334,14 @@ windows.startInputMetrics = function (that) {
             // be copied, otherwise the memory will be re-used.
             var dup = new lparam.type();
             lparam.copy(dup.ref());
-            process.nextTick(windows.inputHook, that, code, wparam, dup);
+            process.nextTick(windows.metrics.inputHook, that, code, wparam, dup);
             return windows.user32.CallNextHookEx(0, code, wparam, lparam);
         };
 
         // The callbacks need to be referenced outside here otherwise the GC will pull the rug from beneath it.
-        windows.keyboardHookCallback = ffi.Callback(
+        windows.metrics.keyboardHookCallback = ffi.Callback(
             windows.types.HANDLE, [windows.types.INT, windows.types.HANDLE, windows.KBDLLHookStructPointer], callHook);
-        windows.mouseHookCallback = ffi.Callback(
+        windows.metrics.mouseHookCallback = ffi.Callback(
             windows.types.HANDLE, [windows.types.INT, windows.types.HANDLE, windows.MSDLLHookStructPointer], callHook);
 
         var WH_KEYBOARD_LL = 13, WH_MOUSE_LL = 14;
@@ -348,25 +349,25 @@ windows.startInputMetrics = function (that) {
 
         // Start the keyboard hook
         that.state.input.keyboardHookHandle =
-            windows.user32.SetWindowsHookExW(WH_KEYBOARD_LL, windows.keyboardHookCallback, hModule, 0);
+            windows.user32.SetWindowsHookExW(WH_KEYBOARD_LL, windows.metrics.keyboardHookCallback, hModule, 0);
 
         if (!that.state.input.keyboardHookHandle) {
             var errCode = windows.kernel32.GetLastError();
-            windows.stopInputMetrics(that);
+            windows.metrics.stopInputMetrics(that);
             fluid.fail("SetWindowsHookExW did not work (keyboard). win32 error: " + errCode);
         }
 
         // Start the mouse hook
         that.state.input.mouseHookHandle =
-            windows.user32.SetWindowsHookExW(WH_MOUSE_LL, windows.mouseHookCallback, hModule, 0);
+            windows.user32.SetWindowsHookExW(WH_MOUSE_LL, windows.metrics.mouseHookCallback, hModule, 0);
 
         if (!that.state.input.mouseHookHandle) {
             var errCode2 = windows.kernel32.GetLastError();
-            windows.stopInputMetrics(that);
+            windows.metrics.stopInputMetrics(that);
             fluid.fail("SetWindowsHookExW did not work (mouse). win32 error: " + errCode2);
         }
 
-        windows.userInput(that);
+        windows.metrics.userInput(that);
     } else {
         // The keyboard hook's ability to work is a side-effect of running with electron.
         fluid.log(fluid.logLevel.WARN, "Input metrics not available without Electron.");
@@ -380,7 +381,7 @@ windows.startInputMetrics = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.stopInputMetrics = function (that) {
+windows.metrics.stopInputMetrics = function (that) {
     var state = that.state.input;
     if (state) {
         // remove the hooks
@@ -405,7 +406,7 @@ windows.stopInputMetrics = function (that) {
 /**
  * A value=>name map of only non-printable keys that will be logged.
  */
-windows.specialKeys = fluid.freezeRecursive((function () {
+windows.metrics.specialKeys = fluid.freezeRecursive((function () {
     // A white-list of key values that can be logged. It must not contain printable keys (like letters or numbers).
     // Also, there needs to be a matching value in windows.API_constants.virtualKeyCodes with the VK_ prefix.
     var keys = [
@@ -435,7 +436,7 @@ windows.specialKeys = fluid.freezeRecursive((function () {
  * @param {Number} timestamp Milliseconds since a fixed point in time.
  * @param {String} specialKey The value key, if it's a special key.
  */
-windows.recordKeyTiming = function (that, timestamp, specialKey) {
+windows.metrics.recordKeyTiming = function (that, timestamp, specialKey) {
     var state = that.state.input;
     var config = that.config.input;
 
@@ -485,17 +486,17 @@ windows.recordKeyTiming = function (that, timestamp, specialKey) {
         keyTime: keyTime
     };
 
-    var modifiers = windows.getModifierKeys();
+    var modifiers = windows.metrics.getModifierKeys();
     if (modifiers.length > 0) {
         record.modifierKeys = modifiers;
     }
 
     if (specialKey) {
         // Double-check that only certain keys are being recorded (it would be a serious blunder).
-        var keycode = parseInt(fluid.keyForValue(windows.specialKeys, specialKey));
+        var keycode = parseInt(fluid.keyForValue(windows.metrics.specialKeys, specialKey));
         if (!!keycode && typeof(specialKey) === "string" && specialKey.length > 1) {
             // Not logging the value of specialKey directly.
-            record.key = windows.specialKeys[keycode];
+            record.key = windows.metrics.specialKeys[keycode];
         }
     }
 
@@ -509,7 +510,7 @@ windows.recordKeyTiming = function (that, timestamp, specialKey) {
  * @param {Number} button Mouse button: 0 movement only, 1 for primary (left), 2 for secondary, W for wheel.
  * @param {Object} pos Mouse cursor coordinates, and wheel distance (if applicable) {x, y, wheel}.
  */
-windows.recordMouseEvent = function (that, button, pos) {
+windows.metrics.recordMouseEvent = function (that, button, pos) {
     var state = that.state.input;
 
     if (state.lastPos) {
@@ -533,7 +534,7 @@ windows.recordMouseEvent = function (that, button, pos) {
 
     if (data) {
         // Add on the modifier keys.
-        var modifiers = windows.getModifierKeys();
+        var modifiers = windows.metrics.getModifierKeys();
         if (modifiers.length > 0) {
             data.modifierKeys = modifiers;
         }
@@ -545,7 +546,7 @@ windows.recordMouseEvent = function (that, button, pos) {
  * Gets the modifier keys that are currently held down.
  * @return {Array<String>} May contain a combination of "CTRL", "ALT", and "SHIFT", identifying which keys are pressed.
  */
-windows.getModifierKeys = function ()
+windows.metrics.getModifierKeys = function ()
 {
     var modifiers = {
         "SHIFT": gpii.windows.API_constants.virtualKeyCodes.VK_SHIFT,
@@ -570,7 +571,7 @@ windows.getModifierKeys = function ()
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.userInput = function (that) {
+windows.metrics.userInput = function (that) {
     var state = that.state.input;
 
     if (state.inactive) {
@@ -585,7 +586,7 @@ windows.userInput = function (that) {
     }
 
     state.lastInputTime = process.hrtime();
-    state.inactivityTimer = setTimeout(windows.userInactive, that.config.input.inactiveTime, that);
+    state.inactivityTimer = setTimeout(windows.metrics.userInactive, that.config.input.inactiveTime, that);
 };
 
 /**
@@ -593,7 +594,7 @@ windows.userInput = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
-windows.userInactive = function (that) {
+windows.metrics.userInactive = function (that) {
     that.state.input.inactive = true;
     that.logMetric("inactive-begin");
 };
@@ -607,9 +608,9 @@ windows.userInactive = function (that) {
  * @param {Number} message The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
  * @param {Number} eventData A KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
  */
-windows.inputHook = function (that, code, message, eventData) {
+windows.metrics.inputHook = function (that, code, message, eventData) {
     if (code >= 0) {
-        windows.userInput(that);
+        windows.metrics.userInput(that);
 
         var wheelDistance;
 
@@ -619,7 +620,7 @@ windows.inputHook = function (that, code, message, eventData) {
             // Key press
             var wanted = false;
 
-            var specialKey = windows.specialKeys[eventData.vkCode];
+            var specialKey = windows.metrics.specialKeys[eventData.vkCode];
 
             // Ignore injected keys.
             var ignoreFlags = windows.API_constants.LLKHF_INJECTED;
@@ -630,7 +631,7 @@ windows.inputHook = function (that, code, message, eventData) {
                     windows.user32.MapVirtualKeyW(eventData.vkCode, windows.API_constants.MAPVK_VK_TO_CHAR);
                 if (wanted) {
                     // Process in the next tick, to allow this function to return soon.
-                    windows.recordKeyTiming(that, eventData.time, specialKey);
+                    windows.metrics.recordKeyTiming(that, eventData.time, specialKey);
                 }
 
                 that.state.input.lastKeyLogged = wanted && !specialKey;
@@ -656,7 +657,7 @@ windows.inputHook = function (that, code, message, eventData) {
             // Log events that are not injected.
             if ((eventData.flags & windows.API_constants.LLMHF_INJECTED) === 0) {
                 var button = wheelDistance ? 0 : (message >> 1) & 3; // 2nd + 3rd bits happen to map to the button
-                windows.recordMouseEvent(that, button, { x: eventData.ptX, y: eventData.ptY, wheel: wheelDistance });
+                windows.metrics.recordMouseEvent(that, button, { x: eventData.ptX, y: eventData.ptY, wheel: wheelDistance });
             }
             break;
         }

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -50,8 +50,14 @@ fluid.defaults("gpii.windowsMetrics", {
     },
     listeners: {
         "onDestroy.stopMetrics": "{that}.events.onStopMetrics",
-        "onStartMetrics.logVersions": "{that}.logVersions",
-        "onStartMetrics.systemInfo": "{that}.logSystemInfo",
+        "{gpii.eventLog}.events.onCreate": [{
+            func: "{that}.logVersions",
+            priority: "last"
+        },
+        {
+            func: "{that}.logSystemInfo",
+            priority: "last"
+        }],
         "onStartMetrics.application": "{that}.startApplicationMetrics",
         "onStopMetrics.application": "{that}.stopApplicationMetrics",
         "onStartMetrics.input": "{that}.startInputMetrics",

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -28,6 +28,7 @@ var gpii = fluid.registerNamespace("gpii"),
 var processesBridge = gpii.processes.windows();
 
 require("../../WindowsUtilities/WindowsUtilities.js");
+require("../../windowMessages");
 
 fluid.defaults("gpii.windowsMetrics", {
     gradeNames: ["fluid.modelComponent", "fluid.contextAware", "gpii.metrics"],
@@ -50,7 +51,12 @@ fluid.defaults("gpii.windowsMetrics", {
         "onStartMetrics.application": "{that}.startApplicationMetrics",
         "onStopMetrics.application": "{that}.stopApplicationMetrics",
         "onStartMetrics.input": "{that}.startInputMetrics",
-        "onStopMetrics.input": "{that}.stopInputMetrics"
+        "onStopMetrics.input": "{that}.stopInputMetrics",
+        "{gpii.windows.messages}.events.onMessage": {
+            funcName: "gpii.windows.metricsWindowMessage",
+            // that, hwnd, msg, wParam, lParam
+            args: [ "{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2", "{arguments}.3" ]
+        }
     },
     invokers: {
         logMetric: {
@@ -72,13 +78,18 @@ fluid.defaults("gpii.windowsMetrics", {
         stopInputMetrics: {
             funcName: "gpii.windows.stopInputMetrics",
             args: ["{that}"]
-        }
+        },
+        windowActivated: {
+            funcName: "gpii.windows.metricsWindowActivated",
+            args: ["{that}", "{arguments}.0"] // window handle (hwnd)
+        },
+        startMessages: "{gpii.windows.messages}.start({that})",
+        stopMessages: "{gpii.windows.messages}.stop({that})",
+        getMessageWindow: "{gpii.windows.messages}.getWindowHandle()"
     },
     members: {
         config: {
             application: {
-                // Milliseconds to poll the active window.
-                precision: 5000
             },
             input: {
                 // Minimum typing session time, in milliseconds.
@@ -191,7 +202,13 @@ windows.startApplicationMetrics = function (that) {
         count: 0
     };
 
-    windows.checkActiveWindow(that, null);
+    // Get the "dynamic constant" value of the WM_SHELLHOOKMESSAGE message identifier.
+    that.WM_SHELLHOOKMESSAGE = windows.user32.RegisterWindowMessageW(windows.stringToWideChar("SHELLHOOK"));
+
+    that.startMessages();
+
+    // Tell Windows to send WM_SHELLHOOKMESSAGE.
+    gpii.windows.user32.RegisterShellHookWindow(that.getMessageWindow());
 };
 
 /**
@@ -200,6 +217,7 @@ windows.startApplicationMetrics = function (that) {
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.stopApplicationMetrics = function (that) {
+    that.stopMessages();
     that.state.application.active = false;
     // Log the currently active window as though it was de-activated.
     windows.logAppActivate(that);
@@ -213,55 +231,71 @@ windows.stopApplicationMetrics = function (that) {
  */
 windows.logAppActivate = function (that) {
     if (that.state.application.currentProcess) {
-        var duration = process.hrtime(that.state.application.currentProcess.timeActivated);
         var data = {
             exe: that.state.application.currentProcess.exe,
-            // Round to the nearest second.
-            duration: duration[0] + (duration[1] < 5e8 ? 0 : 1)
+            window: that.state.application.currentProcess.pid.toString(36) + "-"
+                + that.state.application.activeWindow.toString(36)
         };
         that.logMetric("app-active", data);
     }
 };
+
 /**
- * Begin checking if the active Window has changed. It will continue to check while application.state.active is true.
+ * Called when an event has been received by the message window.
  *
- * @param {Component} that The gpii.windowsMetrics instance.
+ * Handles the WM_SHELLHOOKMESSAGE message.
+ *
+ * @param {Component} that The gpii.windowsMetrics component.
+ * @param {Number} hwnd The window handle of the message window.
+ * @param {Number} msg The message identifier.
+ * @param {Number} wParam Message specific data.
+ * #param {Object} lParam Additional message specific data (passed, but not used).
  */
-windows.checkActiveWindow = function (that) {
-    var activePid = 0;
-    var lastHwnd = 0;
-    if (!that.state.application.currentProcess) {
-        that.state.application.currentProcess = {};
+windows.metricsWindowMessage = function (that, hwnd, msg, wParam) {
+
+    if (msg === that.WM_SHELLHOOKMESSAGE) {
+        if (wParam === windows.API_constants.HSHELL_WINDOWACTIVATED ||
+            wParam === windows.API_constants.HSHELL_RUDEAPPACTIVATED) {
+            // Run the code in the next tick so this function can return soon, as it's a window procedure.
+            process.nextTick(that.windowActivated);
+        }
     }
-    that.state.application.currentProcess.timeActivated = process.hrtime();
+};
 
-    windows.waitForCondition(function () {
-        // Get the process ID that owns the active Window.
-        var hwnd = windows.user32.GetForegroundWindow();
+/**
+ * Called when a window has been activated.
+ * @param {Component} that The gpii.windowsMetrics component.
+ */
+windows.metricsWindowActivated = function (that) {
+    var state = that.state.application;
+
+    // Even though the handle to the active window is passed via WM_SHELLHOOKMESSAGE, it's been known to lie (with UWP
+    // apps).
+    var hwnd = windows.user32.GetForegroundWindow();
+    if (hwnd !== state.activeWindow) {
+        state.activeWindow = hwnd;
+
+        var activePid = null;
+        var exePath = null;
+
         if (hwnd) {
-            if (hwnd !== lastHwnd) {
-                lastHwnd = hwnd;
-            }
             activePid = windows.getWindowProcessId(hwnd);
+            if (activePid) {
+                exePath = processesBridge.getProcessPath(activePid);
+            }
         }
-        return activePid !== that.state.application.currentProcess.pid || !that.state.application.active;
-    }, {
-        pollDelay: that.config.application.precision
-    }).then(function () {
-        if (that.state.application.active) {
-            // Log how long the last window was active.
-            windows.logAppActivate(that);
 
-            var exePath = processesBridge.getProcessPath(activePid);
-            that.state.application.currentProcess.pid = activePid;
-            that.state.application.currentProcess.exe = exePath;
+        that.state.application.currentProcess = {
+            pid: activePid,
+            exe: exePath
+        };
 
-            // Also perform the "application launch" metric here. A process having its window activated implies it's
-            // been launched.
-            windows.checkNewApplication(that);
-            windows.checkActiveWindow(that);
-        }
-    });
+        // Also perform the "application launch" metric here. A process having its window activated implies it's
+        // been launched.
+        windows.checkNewApplication(that);
+
+        windows.logAppActivate(that);
+    }
 };
 
 /**
@@ -273,7 +307,7 @@ windows.checkActiveWindow = function (that) {
  *
  * This comes with the following limitations:
  * - The process needs a window-message loop. Fortunately, Electron has one so this means it will only work if running
- *   via gpii-app (otherwise this becomes an interesting way of disabling the keyboard).
+ *   via gpii-app.
  * - It can't see the keys that are destined to a window owned by a process running as Administrator (and rightly so).
  * - The hook call-back has to return in a timely manner - not only because it would cause key presses to lag, but also
  *   Windows will silently remove the hook if it times out. The time is unspecified (but it can be set in the registry).

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -161,13 +161,16 @@ windows.getMachineID = function () {
 };
 
 /**
- * Logs the version of the gpii-app, gpii-windows, and gpii-universal modules.
+ * Logs the version of this, the gpii-app, gpii-windows, and gpii-universal modules.
+ *
+ * The logging of this module can be used to identify changes in the data structures, independent of the other releases.
+ *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.metrics.logVersions = function (that) {
     var data = {};
 
-    var modules = [ "gpii-app", "gpii-windows", "gpii-universal" ];
+    var modules = [ "windowsMetrics", "gpii-app", "gpii-windows", "gpii-universal" ];
 
     fluid.each(modules, function (moduleName) {
         var version;

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -27,8 +27,7 @@ var gpii = fluid.registerNamespace("gpii"),
 
 var processesBridge = gpii.processes.windows();
 
-fluid.require("%gpii-windows/gpii/node_modules/WindowsUtilities/WindowsUtilities.js");
-
+require("../../WindowsUtilities/WindowsUtilities.js");
 
 fluid.defaults("gpii.windowsMetrics", {
     gradeNames: ["fluid.modelComponent", "fluid.contextAware", "gpii.metrics"],
@@ -281,8 +280,11 @@ windows.startInputMetrics = function (that) {
     windows.stopInputMetrics(that);
     if (process.versions.electron) {
         var callHook = function (code, wparam, lparam) {
-            // Handle the hook in the next tick, to allow the hook callback to return quickly.
-            process.nextTick(windows.inputHook, that, code, wparam, lparam);
+            // Handle the hook in the next tick, to allow the hook callback to return quickly. The lparam data needs to
+            // be copied, otherwise the memory will be re-used.
+            var dup = new lparam.type();
+            lparam.copy(dup.ref());
+            process.nextTick(windows.inputHook, that, code, wparam, dup);
             return windows.user32.CallNextHookEx(0, code, wparam, lparam);
         };
 
@@ -447,8 +449,8 @@ windows.recordKeyTiming = function (that, timestamp, specialKey) {
  * Records a mouse event. Movement isn't logged, but the distance is accumulated.
  *
  * @param {Component} that The gpii.windowsMetrics instance.
- * @param {Number} button Mouse button: 0 movement only, 1 for primary (left) or 2 or secondary.
- * @param {Object} pos mouse cursor coordinates {x, y}.
+ * @param {Number} button Mouse button: 0 movement only, 1 for primary (left), 2 for secondary, W for wheel.
+ * @param {Object} pos Mouse cursor coordinates, and wheel distance (if applicable) {x, y, wheel}.
  */
 windows.recordMouseEvent = function (that, button, pos) {
     var state = that.state.input;
@@ -459,12 +461,21 @@ windows.recordMouseEvent = function (that, button, pos) {
 
     state.lastPos = pos;
 
-    if (button) {
-        that.logMetric("mouse", {
+    // log click or wheel events
+    var data;
+    if (pos.wheel) {
+        data = {wheel: pos.wheel};
+    } else if (button) {
+        data = {
             button: button,
             distance: Math.round(state.distance)
-        });
+        };
+        // reset the distance accumulator
         state.distance = 0;
+    }
+
+    if (data) {
+        that.logMetric("mouse", data);
     }
 };
 
@@ -508,14 +519,14 @@ windows.userInactive = function (that) {
  * @param {Component} that The gpii.windowsMetrics instance.
  * @param {Number} code If less than zero, then don't process.
  * @param {Number} wparam The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
- * @param {Number} lparam A pointer to a KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
+ * @param {Number} lparam A KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
  */
 windows.inputHook = function (that, code, wparam, lparam) {
     if (code >= 0) {
         windows.userInput(that);
 
-        // For testing, allows the object to be passed directly rather than a ffi/ref struct.
-        var eventData = lparam.deref ? lparam.deref() : lparam;
+        var eventData = lparam;
+        var wheelDistance;
 
         switch (wparam) {
         case windows.API_constants.WM_KEYUP:
@@ -540,13 +551,26 @@ windows.inputHook = function (that, code, wparam, lparam) {
             }
             break;
 
+        case windows.API_constants.WM_MOUSEWHEEL:
+            // "The high-order word indicates the distance the wheel is rotated, expressed in multiples or divisions of
+            // WHEEL_DELTA, which is 120"
+            var WHEEL_DELTA = 120;
+            wheelDistance = windows.hiWord(eventData.mouseData);
+            // unsigned to signed
+            if (wheelDistance >= 0x8000) {
+                wheelDistance -= 0x10000;
+            }
+            // number of notches
+            wheelDistance /= WHEEL_DELTA;
+
+            // fall-through
         case windows.API_constants.WM_MOUSEMOVE:
         case windows.API_constants.WM_LBUTTONUP:
         case windows.API_constants.WM_RBUTTONUP:
-            // Don't log injected events.
+            // Log events that are not injected.
             if ((eventData.flags & windows.API_constants.LLMHF_INJECTED) === 0) {
-                var button = (wparam >> 1) & 3; // 2nd + 3rd bits happen to map to the button
-                windows.recordMouseEvent(that, button, { x: eventData.ptX, y: eventData.ptY });
+                var button = wheelDistance ? 0 : (wparam >> 1) & 3; // 2nd + 3rd bits happen to map to the button
+                windows.recordMouseEvent(that, button, { x: eventData.ptX, y: eventData.ptY, wheel: wheelDistance });
             }
             break;
         }

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -30,6 +30,7 @@ var processesBridge = gpii.processes.windows();
 
 require("../../WindowsUtilities/WindowsUtilities.js");
 require("../../windowMessages");
+require("../../displaySettingsHandler");
 
 fluid.defaults("gpii.windowsMetrics", {
     gradeNames: ["fluid.modelComponent", "fluid.contextAware", "gpii.metrics"],
@@ -202,11 +203,17 @@ windows.metrics.logSystemInfo = function (that) {
     var oneGB = 0x40000000;
 
     var cpus = os.cpus();
+    var resolution = windows.display.getScreenResolution();
+    var desktop = windows.display.getDesktopSize();
+    var scale = (resolution.width / desktop.width).toPrecision(3);
 
     var data = {
         cpu: cpus[0].model,
         cores: cpus.length,
         memory: (os.totalmem / oneGB).toPrecision(2),
+
+        resolution: resolution.width + "x" + resolution.height,
+        scale: scale,
 
         osRelease: os.release(),
         osEdition: windows.readRegistryKey("HKEY_LOCAL_MACHINE",

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -49,6 +49,8 @@ fluid.defaults("gpii.windowsMetrics", {
     },
     listeners: {
         "onDestroy.stopMetrics": "{that}.events.onStopMetrics",
+        "onStartMetrics.logVersions": "{that}.logVersions",
+        "onStartMetrics.systemInfo": "{that}.logSystemInfo",
         "onStartMetrics.application": "{that}.startApplicationMetrics",
         "onStopMetrics.application": "{that}.stopApplicationMetrics",
         "onStartMetrics.input": "{that}.startInputMetrics",
@@ -63,6 +65,14 @@ fluid.defaults("gpii.windowsMetrics", {
         logMetric: {
             func: "{eventLog}.logEvent",
             args: ["metrics", "{arguments}.0", "{arguments}.1"]
+        },
+        logVersions: {
+            funcName: "gpii.windows.metrics.logVersions",
+            args: ["{that}"]
+        },
+        logSystemInfo: {
+            funcName: "gpii.windows.metrics.logSystemInfo",
+            args: ["{that}"]
         },
         startApplicationMetrics: {
             funcName: "gpii.windows.metrics.startApplicationMetrics",
@@ -148,6 +158,61 @@ windows.getMachineID = function () {
     var machineID = windows.readRegistryKey(
         "HKEY_LOCAL_MACHINE", "64:SOFTWARE\\Microsoft\\Cryptography", "MachineGuid", "REG_SZ").value;
     return machineID;
+};
+
+/**
+ * Logs the version of the gpii-app, gpii-windows, and gpii-universal modules.
+ * @param {Component} that The gpii.windowsMetrics instance.
+ */
+windows.metrics.logVersions = function (that) {
+    var data = {};
+
+    var modules = [ "gpii-app", "gpii-windows", "gpii-universal" ];
+
+    fluid.each(modules, function (moduleName) {
+        var version;
+        if (fluid.module.modules[moduleName]) {
+            var packageData = fluid.require("%" + moduleName + "/package.json");
+            version = packageData.version;
+        } else {
+            version = "none";
+        }
+        data[moduleName] = version;
+    });
+
+    that.logMetric("version", data);
+};
+
+/**
+ * Logs information about the system, consisting of:
+ *
+ * - CPU & memory.
+ * - Windows version.
+ * - System name and manufacturer.
+ *
+ *
+ * @param {Component} that The gpii.windowsMetrics instance.
+ */
+windows.metrics.logSystemInfo = function (that) {
+    var os = require("os");
+
+    var oneGB = 0x40000000;
+
+    var data = {
+        cpu: os.cpus()[0].model,
+        memory: (os.totalmem / oneGB).toPrecision(2),
+
+        osRelease: os.release(),
+        osEdition: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
+            "64:SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", "REG_SZ").value,
+
+        systemMfr: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
+            "64:SYSTEM\\CurrentControlSet\\Control\\SystemInformation", "SystemManufacturer", "REG_SZ").value,
+        systemName: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
+            "64:SYSTEM\\CurrentControlSet\\Control\\SystemInformation", "SystemProductName", "REG_SZ").value
+    };
+
+    that.logMetric("system-info", data);
 };
 
 /**

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -205,6 +205,7 @@ windows.metrics.logSystemInfo = function (that) {
         osRelease: os.release(),
         osEdition: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
             "64:SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", "REG_SZ").value,
+        osBits: windows.isWow64() || os.arch() === "x64",
 
         systemMfr: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
             "64:SYSTEM\\CurrentControlSet\\Control\\SystemInformation", "SystemManufacturer", "REG_SZ").value,
@@ -379,21 +380,21 @@ windows.metrics.windowActivated = function (that) {
  *   Windows will silently remove the hook if it times out. The time is unspecified (but it can be set in the registry).
  * - Anti-virus software may question this.
  *
+ * The environment variable GPII_NO_INPUT_METRICS can be set to disable input metrics.
+ *
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.metrics.startInputMetrics = function (that) {
-    var debugMetrics = false;
-    if (process.env.GPII_DEBUG_METRICS) {
-        // Enable the input metrics by polling for messages.
-        debugMetrics = true;
-        gpii.windows.messages.messagePumpDelay = 1;
-    }
-
     windows.metrics.stopInputMetrics(that);
 
     that.state.input = fluid.copy(that.options.initialState.input);
 
-    if (process.versions.electron || debugMetrics) {
+    var disable = process.env.GPII_NO_INPUT_METRICS;
+
+    if (disable) {
+        fluid.log(fluid.logLevel.WARN, "Input metrics disabled with GPII_NO_INPUT_METRICS.");
+        that.logMetrics("input-disabled");
+    } else if (process.versions.electron) {
         var callHook = function (code, wparam, lparam) {
             // Handle the hook in the next tick, to allow the hook callback to return quickly. The lparam data needs to
             // be copied, otherwise the memory will be re-used.

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -91,24 +91,29 @@ fluid.defaults("gpii.windowsMetrics", {
                 inactiveTime: 300000
             }
         },
+        // set to initialState on startup
         state: {
-            application: {},
-            input: {
-                keyboardHookHandle: null,
-                mouseHookHandle: null,
-                lastKeyLogged: null,
-                lastKeyTime: 0,
-                // Timestamp of typing session start.
-                sessionStart: null,
-                // Number of keys in the typing session.
-                keyCount: 0,
-                // Number of special keys
-                specialCount: 0,
-                // Mouse position
-                lastPos: null,
-                distance: 0,
-                lastInputTime: 0
-            }
+            application: null,
+            input: null
+        }
+    },
+    initialState: {
+        application: {},
+        input: {
+            keyboardHookHandle: null,
+            mouseHookHandle: null,
+            lastKeyLogged: null,
+            lastKeyTime: 0,
+            // Timestamp of typing session start.
+            sessionStart: null,
+            // Number of keys in the typing session.
+            keyCount: 0,
+            // Number of special keys
+            specialCount: 0,
+            // Mouse position
+            lastPos: null,
+            distance: 0,
+            lastInputTime: 0
         }
     }
 });
@@ -180,12 +185,12 @@ windows.checkNewApplication = function (that) {
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.startApplicationMetrics = function (that) {
-    that.state.application = {
-        active: true,
-        runningApplications: {
-            count: 0
-        }
+    that.state.application = fluid.copy(that.options.initialState.application);
+    that.state.application.active = true;
+    that.state.application.runningApplications = {
+        count: 0
     };
+
     windows.checkActiveWindow(that, null);
 };
 
@@ -277,8 +282,18 @@ windows.checkActiveWindow = function (that) {
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.startInputMetrics = function (that) {
+    var debugMetrics = false;
+    if (process.env.GPII_DEBUG_METRICS) {
+        // Enable the input metrics by polling for messages.
+        debugMetrics = true;
+        gpii.windows.messages.messagePumpDelay = 1;
+    }
+
     windows.stopInputMetrics(that);
-    if (process.versions.electron) {
+
+    that.state.input = fluid.copy(that.options.initialState.input);
+
+    if (process.versions.electron || debugMetrics) {
         var callHook = function (code, wparam, lparam) {
             // Handle the hook in the next tick, to allow the hook callback to return quickly. The lparam data needs to
             // be copied, otherwise the memory will be re-used.
@@ -333,21 +348,23 @@ windows.startInputMetrics = function (that) {
  */
 windows.stopInputMetrics = function (that) {
     var state = that.state.input;
-    // remove the hooks
-    if (state.keyboardHookHandle) {
-        windows.user32.UnhookWindowsHookEx(state.keyboardHookHandle);
-    }
-    if (state.mouseHookHandle) {
-        windows.user32.UnhookWindowsHookEx(state.mouseHookHandle);
-    }
-    state.keyboardHookHandle = null;
-    state.keyboardHookCallback = null;
-    state.mouseHookHandle = null;
-    state.mouseHookCallback = null;
+    if (state) {
+        // remove the hooks
+        if (state.keyboardHookHandle) {
+            windows.user32.UnhookWindowsHookEx(state.keyboardHookHandle);
+        }
+        if (state.mouseHookHandle) {
+            windows.user32.UnhookWindowsHookEx(state.mouseHookHandle);
+        }
+        state.keyboardHookHandle = null;
+        state.keyboardHookCallback = null;
+        state.mouseHookHandle = null;
+        state.mouseHookCallback = null;
 
-    if (state.inactivityTimer) {
-        clearTimeout(state.inactivityTimer);
-        state.inactivityTimer = null;
+        if (state.inactivityTimer) {
+            clearTimeout(state.inactivityTimer);
+            state.inactivityTimer = null;
+        }
     }
 };
 
@@ -361,7 +378,8 @@ windows.specialKeys = fluid.freezeRecursive((function () {
         "BACK", "TAB", "RETURN", "ESCAPE", "PAGEUP", "PAGEDOWN", "END", "HOME", "LEFT", "UP", "RIGHT", "DOWN",
         "SELECT", "PRINT", "EXECUTE", "SNAPSHOT", "INSERT", "DELETE", "HELP", "LWIN", "RWIN", "SCROLL", "NUMLOCK",
         "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12", "F13", "F14", "F15", "F16",
-        "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24"
+        "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24",
+        "CONTROL", "MENU", "SHIFT"
     ];
     var special = {};
 
@@ -433,6 +451,11 @@ windows.recordKeyTiming = function (that, timestamp, specialKey) {
         keyTime: keyTime
     };
 
+    var modifiers = windows.getModifierKeys();
+    if (modifiers.length > 0) {
+        record.modifierKeys = modifiers;
+    }
+
     if (specialKey) {
         // Double-check that only certain keys are being recorded (it would be a serious blunder).
         var keycode = parseInt(fluid.keyForValue(windows.specialKeys, specialKey));
@@ -475,8 +498,37 @@ windows.recordMouseEvent = function (that, button, pos) {
     }
 
     if (data) {
+        // Add on the modifier keys.
+        var modifiers = windows.getModifierKeys();
+        if (modifiers.length > 0) {
+            data.modifierKeys = modifiers;
+        }
         that.logMetric("mouse", data);
     }
+};
+
+/**
+ * Gets the modifier keys that are currently held down.
+ * @return {Array<String>} May contain a combination of "CTRL", "ALT", and "SHIFT", identifying which keys are pressed.
+ */
+windows.getModifierKeys = function ()
+{
+    var modifiers = {
+        "SHIFT": gpii.windows.API_constants.virtualKeyCodes.VK_SHIFT,
+        "CTRL": gpii.windows.API_constants.virtualKeyCodes.VK_CONTROL,
+        "ALT": gpii.windows.API_constants.virtualKeyCodes.VK_MENU
+    };
+
+    var togo = [];
+
+    fluid.each(modifiers, function (keycode, name) {
+        var down = windows.user32.GetKeyState(keycode) & 0x8000;
+        if (down) {
+            togo.push(name);
+        }
+    });
+
+    return togo;
 };
 
 /**
@@ -518,25 +570,25 @@ windows.userInactive = function (that) {
  *
  * @param {Component} that The gpii.windowsMetrics instance.
  * @param {Number} code If less than zero, then don't process.
- * @param {Number} wparam The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
- * @param {Number} lparam A KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
+ * @param {Number} message The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
+ * @param {Number} eventData A KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
  */
-windows.inputHook = function (that, code, wparam, lparam) {
+windows.inputHook = function (that, code, message, eventData) {
     if (code >= 0) {
         windows.userInput(that);
 
-        var eventData = lparam;
         var wheelDistance;
 
-        switch (wparam) {
+        switch (message) {
+        case windows.API_constants.WM_SYSKEYUP:
         case windows.API_constants.WM_KEYUP:
             // Key press
             var wanted = false;
 
             var specialKey = windows.specialKeys[eventData.vkCode];
 
-            // Ignore injected and Alt keys.
-            var ignoreFlags = windows.API_constants.LLKHF_INJECTED | windows.API_constants.LLKHF_ALTDOWN;
+            // Ignore injected keys.
+            var ignoreFlags = windows.API_constants.LLKHF_INJECTED;
 
             if ((eventData.flags & ignoreFlags) === 0) {
                 // If the key doesn't generate a character, then don't count it.
@@ -569,7 +621,7 @@ windows.inputHook = function (that, code, wparam, lparam) {
         case windows.API_constants.WM_RBUTTONUP:
             // Log events that are not injected.
             if ((eventData.flags & windows.API_constants.LLMHF_INJECTED) === 0) {
-                var button = wheelDistance ? 0 : (wparam >> 1) & 3; // 2nd + 3rd bits happen to map to the button
+                var button = wheelDistance ? 0 : (message >> 1) & 3; // 2nd + 3rd bits happen to map to the button
                 windows.recordMouseEvent(that, button, { x: eventData.ptX, y: eventData.ptY, wheel: wheelDistance });
             }
             break;

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -201,14 +201,17 @@ windows.metrics.logSystemInfo = function (that) {
 
     var oneGB = 0x40000000;
 
+    var cpus = os.cpus();
+
     var data = {
-        cpu: os.cpus()[0].model,
+        cpu: cpus[0].model,
+        cores: cpus.length,
         memory: (os.totalmem / oneGB).toPrecision(2),
 
         osRelease: os.release(),
         osEdition: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
             "64:SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", "REG_SZ").value,
-        osBits: windows.isWow64() || os.arch() === "x64",
+        osBits: windows.isWow64() || os.arch() === "x64" ? "64" : "32",
 
         systemMfr: windows.readRegistryKey("HKEY_LOCAL_MACHINE",
             "64:SYSTEM\\CurrentControlSet\\Control\\SystemInformation", "SystemManufacturer", "REG_SZ").value,

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -138,7 +138,7 @@ windows.getMachineID = function () {
  * Check if the currently active pid+exe has been seen before. If not, log it as an application launch.
  * Called when a window has been activated.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.checkNewApplication = function (that) {
     var runningApplications = that.state.application.runningApplications;
@@ -178,7 +178,7 @@ windows.checkNewApplication = function (that) {
 /**
  * Begin monitoring the application launches and active windows.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.startApplicationMetrics = function (that) {
     that.state.application = {
@@ -193,7 +193,7 @@ windows.startApplicationMetrics = function (that) {
 /**
  * Stops collecting the application metrics.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.stopApplicationMetrics = function (that) {
     that.state.application.active = false;
@@ -205,7 +205,7 @@ windows.stopApplicationMetrics = function (that) {
  * Logs the application active metric - how long an application has been active for.
  * Called when a new window is being activated, while currentProcess refers to the application losing focus.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.logAppActivate = function (that) {
     if (that.state.application.currentProcess) {
@@ -221,7 +221,7 @@ windows.logAppActivate = function (that) {
 /**
  * Begin checking if the active Window has changed. It will continue to check while application.state.active is true.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.checkActiveWindow = function (that) {
     var activePid = 0;
@@ -275,7 +275,7 @@ windows.checkActiveWindow = function (that) {
  *   Windows will silently remove the hook if it times out. The time is unspecified (but it can be set in the registry).
  * - Anti-virus software may question this.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.startInputMetrics = function (that) {
     windows.stopInputMetrics(that);
@@ -327,7 +327,7 @@ windows.startInputMetrics = function (that) {
  *
  * Removes the low-level keyboard hook from the system, and sends the last timings to the log.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.stopInputMetrics = function (that) {
     var state = that.state.input;
@@ -377,9 +377,9 @@ windows.specialKeys = fluid.freezeRecursive((function () {
  * Records the timing of a key press. This only logs the time between two keys being pressed, and not the actual
  * value of the key (unless it's a special key). Characters aren't being recorded.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
- * @param timestamp {Number} Milliseconds since a fixed point in time.
- * @param specialKey {String} The value key, if it's a special key.
+ * @param {Component} that The gpii.windowsMetrics instance.
+ * @param {Number} timestamp Milliseconds since a fixed point in time.
+ * @param {String} specialKey The value key, if it's a special key.
  */
 windows.recordKeyTiming = function (that, timestamp, specialKey) {
     var state = that.state.input;
@@ -446,10 +446,9 @@ windows.recordKeyTiming = function (that, timestamp, specialKey) {
 /**
  * Records a mouse event. Movement isn't logged, but the distance is accumulated.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
- * @param eventType {String} "move" or "button".
- * @param button {Number} Mouse button: 0 movement only, 1 for primary (left) or 2 or secondary.
- * @param pos {Object} mouse cursor coordinates {x, y}.
+ * @param {Component} that The gpii.windowsMetrics instance.
+ * @param {Number} button Mouse button: 0 movement only, 1 for primary (left) or 2 or secondary.
+ * @param {Object} pos mouse cursor coordinates {x, y}.
  */
 windows.recordMouseEvent = function (that, button, pos) {
     var state = that.state.input;
@@ -472,7 +471,7 @@ windows.recordMouseEvent = function (that, button, pos) {
 /**
  * Called by inputHook when it receives some input, then waits for no further input to detect inactivity.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.userInput = function (that) {
     var state = that.state.input;
@@ -495,7 +494,7 @@ windows.userInput = function (that) {
 /**
  * Called when there's been some time since receiving input from the user.
  *
- * @param that {Component} The gpii.windowsMetrics instance.
+ * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.userInactive = function (that) {
     that.state.input.inactive = true;
@@ -506,14 +505,12 @@ windows.userInactive = function (that) {
  * The keyboard hook callback. Called when a key is pressed or released.
  * https://msdn.microsoft.com/library/ms644985
  *
- * @param that {Component} The gpii.windowsMetrics instance.
- * @param code {Number} If less than zero, then don't process.
- * @param wparam {Number} The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
- * @param lparam {Number} A pointer to a KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
- * @return {Number} The return value of CallNextHookEx.
+ * @param {Component} that The gpii.windowsMetrics instance.
+ * @param {Number} code If less than zero, then don't process.
+ * @param {Number} wparam The input message (eg, WM_KEYDOWN or WM_MOUSEMOVE).
+ * @param {Number} lparam A pointer to a KBDLLHOOKSTRUCT or MSDLLHOOKSTRUCT structure.
  */
 windows.inputHook = function (that, code, wparam, lparam) {
-    var togo;
     if (code >= 0) {
         windows.userInput(that);
 
@@ -554,5 +551,4 @@ windows.inputHook = function (that, code, wparam, lparam) {
             break;
         }
     }
-    return togo;
 };

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -772,8 +772,6 @@ jqUnit.asyncTest("Testing application metrics", function () {
         }
     });
 
-    windowsMetrics.config.application.precision = 1;
-
     var processesBridge = gpii.processes.windows();
 
     // Pick three windows (owned by different processes) that already exist, and pretend they've became active by
@@ -810,9 +808,14 @@ jqUnit.asyncTest("Testing application metrics", function () {
     var activateWindow = function (count) {
         activeWindowIndex = (activeWindowIndex + 1) % windows.length;
 
-        if (count > 0) {
+        // Pretend the "window has been activated" notification has been received. A fuller test would have sent the
+        // actual message. However, there isn't a real message loop when running under node (rather than electron).
+        gpii.windows.metricsWindowMessage(windowsMetrics, 0, windowsMetrics.WM_SHELLHOOKMESSAGE,
+            gpii.windows.API_constants.HSHELL_WINDOWACTIVATED, 0);
 
+        if (count > 0) {
             if (!windows[activeWindowIndex].done) {
+                // The launch event is only expected on a window's first occurrence.
                 expectedLines.push({
                     module: "metrics",
                     event: "app-launch",
@@ -822,26 +825,28 @@ jqUnit.asyncTest("Testing application metrics", function () {
                 });
                 windows[activeWindowIndex].done = true;
             }
+
             expectedLines.push({
                 module: "metrics",
                 event: "app-active",
                 data: {
                     exe: windows[activeWindowIndex].exe,
-                    duration: fluid.VALUE
+                    window: fluid.VALUE
                 }
             });
 
-            setTimeout(activateWindow, 200, count - 1);
+            process.nextTick(activateWindow, count - 1);
         } else {
             windowsMetrics.stopApplicationMetrics();
             gpii.tests.metrics.completeLogTest(logFile, expectedLines);
         }
     };
 
-    activateWindow(windows.length * 2);
-
     // Start monitoring.
     windowsMetrics.startApplicationMetrics();
+
+    activateWindow(windows.length * 2);
+
 });
 
 /**

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -1152,6 +1152,7 @@ jqUnit.asyncTest("Testing version and system info logging", function () {
             module: "metrics",
             event: "version",
             data: {
+                "windowsMetrics": fluid.VALUE,
                 "gpii-app": fluid.VALUE,
                 "gpii-windows": fluid.VALUE,
                 "gpii-universal": fluid.VALUE

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -1132,3 +1132,42 @@ jqUnit.asyncTest("Testing input metrics: inactivity", function () {
         jqUnit.start();
     }, 10);
 });
+
+jqUnit.asyncTest("Testing version and system info logging", function () {
+
+    jqUnit.expect(1);
+    var logFile = gpii.tests.metrics.setLogFile();
+
+    var windowsMetrics = gpii.tests.metrics.windowsMetricsWrapper({
+        members: {
+            logFilePath: logFile
+        }
+    });
+
+    windowsMetrics.events.onStartMetrics.fire();
+
+    gpii.tests.metrics.completeLogTest(logFile, [
+        {
+
+            module: "metrics",
+            event: "version",
+            data: {
+                "gpii-app": fluid.VALUE,
+                "gpii-windows": fluid.VALUE,
+                "gpii-universal": fluid.VALUE
+            }
+        }, {
+
+            module: "metrics",
+            event: "system-info",
+            data: {
+                "cpu": fluid.VALUE,
+                "memory": fluid.VALUE,
+                "osRelease": fluid.VALUE,
+                "osEdition": fluid.VALUE,
+                "systemMfr": fluid.VALUE,
+                "systemName": fluid.VALUE
+            }
+        }
+    ]);
+});

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -520,6 +520,82 @@ gpii.tests.metrics.inputHookTests = fluid.freezeRecursive([
             // (-25,-30) + (10,20) => 39 + 22 = 61
             data: { button: 1, distance: 61 }
         }
+    },
+    {   // Mouse wheel up
+        input: {
+            nCode: 0,
+            wParam: gpii.windows.API_constants.WM_MOUSEWHEEL,
+            lParam: {
+                ptX: 1,
+                ptY: 2,
+                mouseData: gpii.windows.makeLong(0, -120),
+                flags: 0,
+                time: 0,
+                dwExtraInfo: 0
+            }
+        },
+        expect: {
+            module: "metrics",
+            event: "mouse",
+            data: { wheel: -1 }
+        }
+    },
+    {   // Mouse wheel down
+        input: {
+            nCode: 0,
+            wParam: gpii.windows.API_constants.WM_MOUSEWHEEL,
+            lParam: {
+                ptX: 1,
+                ptY: 2,
+                mouseData: gpii.windows.makeLong(0, 120),
+                flags: 0,
+                time: 0,
+                dwExtraInfo: 0
+            }
+        },
+        expect: {
+            module: "metrics",
+            event: "mouse",
+            data: { wheel: 1 }
+        }
+    },
+    {   // Mouse wheel up multiple
+        input: {
+            nCode: 0,
+            wParam: gpii.windows.API_constants.WM_MOUSEWHEEL,
+            lParam: {
+                ptX: 1,
+                ptY: 2,
+                mouseData: gpii.windows.makeLong(0, -120 * 5),
+                flags: 0,
+                time: 0,
+                dwExtraInfo: 0
+            }
+        },
+        expect: {
+            module: "metrics",
+            event: "mouse",
+            data: { wheel: -5 }
+        }
+    },
+    {   // Mouse wheel down multiple
+        input: {
+            nCode: 0,
+            wParam: gpii.windows.API_constants.WM_MOUSEWHEEL,
+            lParam: {
+                ptX: 1,
+                ptY: 2,
+                mouseData: gpii.windows.makeLong(0, 120 * 3),
+                flags: 0,
+                time: 0,
+                dwExtraInfo: 0
+            }
+        },
+        expect: {
+            module: "metrics",
+            event: "mouse",
+            data: { wheel: 3 }
+        }
     }
 ]);
 

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -664,7 +664,9 @@ gpii.tests.metrics.deepMatch = function (subject, expected, maxDepth) {
     for (var prop in expected) {
         if (expected.hasOwnProperty(prop)) {
             var exp = expected[prop];
-            if (fluid.isMarker(exp, fluid.VALUE)) {
+            if (exp instanceof RegExp) {
+                match = exp.test(subject[prop]);
+            } else if (fluid.isMarker(exp, fluid.VALUE)) {
                 // match any value
                 match = subject.hasOwnProperty(prop);
             } else if (fluid.isMarker(exp, fluid.NO_VALUE)) {
@@ -1163,9 +1165,11 @@ jqUnit.asyncTest("Testing version and system info logging", function () {
             event: "system-info",
             data: {
                 "cpu": fluid.VALUE,
-                "memory": fluid.VALUE,
+                "cores": /^[1-9][0-9]?$/,
+                "memory": /^[0-9]+\.[0-9]*$/,
+                "osBits": /^(32|64)$/,
                 "osRelease": fluid.VALUE,
-                "osEdition": fluid.VALUE,
+                "osEdition": /Windows/,
                 "systemMfr": fluid.VALUE,
                 "systemName": fluid.VALUE
             }

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -810,7 +810,7 @@ jqUnit.asyncTest("Testing application metrics", function () {
 
         // Pretend the "window has been activated" notification has been received. A fuller test would have sent the
         // actual message. However, there isn't a real message loop when running under node (rather than electron).
-        gpii.windows.metricsWindowMessage(windowsMetrics, 0, windowsMetrics.WM_SHELLHOOKMESSAGE,
+        gpii.windows.metrics.windowMessage(windowsMetrics, 0, windowsMetrics.WM_SHELLHOOKMESSAGE,
             gpii.windows.API_constants.HSHELL_WINDOWACTIVATED, 0);
 
         if (count > 0) {
@@ -877,7 +877,7 @@ gpii.tests.metrics.recordKeyTimingTests = function (theTests) {
 
         // "press" the keys
         fluid.each(fluid.makeArray(test.input), function (input) {
-            gpii.windows.recordKeyTiming(windowsMetrics, input.timestamp, input.key);
+            gpii.windows.metrics.recordKeyTiming(windowsMetrics, input.timestamp, input.key);
         });
 
         expectedLines.push.apply(expectedLines, fluid.makeArray(test.expect));
@@ -928,7 +928,7 @@ jqUnit.asyncTest("Testing input metrics: inputHook", function () {
     var testInput = function () {
         fluid.each(testData, function (test) {
             currentTest = test.input;
-            gpii.windows.inputHook(windowsMetrics, currentTest.nCode, currentTest.wParam, currentTest.lParam);
+            gpii.windows.metrics.inputHook(windowsMetrics, currentTest.nCode, currentTest.wParam, currentTest.lParam);
 
             // insert the modifierKeys field to the expect result, if necessary.
             var expected = fluid.transform(fluid.makeArray(test.expect), function (expect) {
@@ -944,12 +944,12 @@ jqUnit.asyncTest("Testing input metrics: inputHook", function () {
     };
 
     // Mock windows.getModifierKeys to return the test data (it's better than simulating the key state)
-    var getModifierKeysOrig = gpii.windows.getModifierKeys;
+    var getModifierKeysOrig = gpii.windows.metrics.getModifierKeys;
     teardowns.push(function () {
-        gpii.windows.getModifierKeys = getModifierKeysOrig;
+        gpii.windows.metrics.getModifierKeys = getModifierKeysOrig;
     });
 
-    gpii.windows.getModifierKeys = function () {
+    gpii.windows.metrics.getModifierKeys = function () {
         return expectedModifiers;
     };
 
@@ -977,7 +977,7 @@ jqUnit.asyncTest("Testing input metrics: inputHook", function () {
 // Ensure no character keys are whitelisted for being logged.
 jqUnit.test("Testing input metrics: inputHook - not logging character keys", function () {
 
-    var keyCodes = Object.keys(gpii.windows.specialKeys);
+    var keyCodes = Object.keys(gpii.windows.metrics.specialKeys);
     jqUnit.expect(keyCodes.length + 2);
 
     // Return true if keyCode corresponds to a character key.
@@ -995,7 +995,7 @@ jqUnit.test("Testing input metrics: inputHook - not logging character keys", fun
         isCharacterKey(gpii.windows.API_constants.virtualKeyCodes.VK_HOME));
 
     fluid.each(keyCodes, function (key) {
-        jqUnit.assertFalse("Keys in windows.specialKeys must all be non-printable: " + gpii.windows.specialKeys[key],
+        jqUnit.assertFalse("Keys in windows.metrics.specialKeys must all be non-printable: " + gpii.windows.metrics.specialKeys[key],
             isCharacterKey(key));
     });
 });
@@ -1025,7 +1025,7 @@ jqUnit.asyncTest("Testing input metrics: inputHook - only logging desired keys",
     // Send every key.
     for (var keyCode = 0; keyCode <= 0xff; keyCode++) {
         lParam.vkCode = keyCode;
-        gpii.windows.inputHook(windowsMetrics, 0, gpii.windows.API_constants.WM_KEYUP, lParam);
+        gpii.windows.metrics.inputHook(windowsMetrics, 0, gpii.windows.API_constants.WM_KEYUP, lParam);
         keyCount++;
     }
 
@@ -1066,7 +1066,7 @@ jqUnit.asyncTest("Testing input metrics: inputHook - only logging desired keys",
                     loggedKeys[key] = true;
 
                     // Make sure the key is supposed to be logged.
-                    var keyCode = fluid.keyForValue(gpii.windows.specialKeys, key);
+                    var keyCode = fluid.keyForValue(gpii.windows.metrics.specialKeys, key);
                     var found = keyCode !== undefined;
                     if (found) {
                         // Double check for the alpha-numeric keys
@@ -1094,7 +1094,7 @@ jqUnit.asyncTest("Testing input metrics: inputHook - only logging desired keys",
         });
 
         // Make sure the test ran fully.
-        var allKeys = fluid.values(gpii.windows.specialKeys);
+        var allKeys = fluid.values(gpii.windows.metrics.specialKeys);
         jqUnit.assertDeepEq("All special keys should have been logged", allKeys, loggedSpecialKeys);
         jqUnit.assertTrue("The self-test bad key should have been found", gotSelfTest);
 
@@ -1119,13 +1119,13 @@ jqUnit.asyncTest("Testing input metrics: inactivity", function () {
 
     jqUnit.assertFalse("Should not be inactive at start", state.inactive);
 
-    gpii.windows.userInput(windowsMetrics);
+    gpii.windows.metrics.userInput(windowsMetrics);
 
     jqUnit.assertFalse("Should not be inactive after first input", state.inactive);
 
     setTimeout(function () {
         jqUnit.assertTrue("Should be inactive after timer", state.inactive);
-        gpii.windows.userInput(windowsMetrics);
+        gpii.windows.metrics.userInput(windowsMetrics);
         jqUnit.assertFalse("Should not be inactive after last input", state.inactive);
 
         windowsMetrics.stopInputMetrics();

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -550,9 +550,10 @@ gpii.tests.metrics.setLogFile = function () {
  * A property's value in the expected object can be the expected value, fluid.VALUE to match any value (just check if
  * the property exists), or fluid.NO_VALUE to check the property doesn't exist.
  *
- * @param subject {Object} The object to check against
- * @param expected {Object} The object containing the values to check for.
- * @param maxDepth {Number} [Optional] How deep to check.
+ * @param {Object} subject The object to check against
+ * @param {Object} expected The object containing the values to check for.
+ * @param {Number} maxDepth [Optional] How deep to check.
+ * @return {Boolean} true if subject matches expected.
  */
 gpii.tests.metrics.deepMatch = function (subject, expected, maxDepth) {
     var match = false;
@@ -592,9 +593,9 @@ gpii.tests.metrics.deepMatch = function (subject, expected, maxDepth) {
 /**
  * Checks the log file for some lines that are expected. (see deepMatch for the matching rules)
  *
- * @param logFile {String} The file to read.
- * @param expected {Object[]} An array of log items to search for (in order of how they should be found).
- * @returns {Promise} Resolves when all expected lines where found, or rejects if the end of the log is reached first.
+ * @param {String} logFile The file to read.
+ * @param {Array<Object>} expected An array of log items to search for (in order of how they should be found).
+ * @return {Promise} Resolves when all expected lines where found, or rejects if the end of the log is reached first.
  */
 gpii.tests.metrics.expectLogLines = function (logFile, expected) {
     jqUnit.expect(expected.length);
@@ -651,8 +652,8 @@ gpii.tests.metrics.expectLogLines = function (logFile, expected) {
 /**
  * Completes a test of logging, by checking if the given log file contains the expected lines.
  *
- * @param logFile {String} The log file.
- * @param expectedLines {Object[]} An array of log items to search for (in order of how they should be found).
+ * @param {String} logFile The log file.
+ * @param {Array<Object>} expectedLines An array of log items to search for (in order of how they should be found).
  */
 gpii.tests.metrics.completeLogTest = function (logFile, expectedLines) {
     gpii.tests.metrics.expectLogLines(logFile, expectedLines).then(function () {
@@ -662,6 +663,7 @@ gpii.tests.metrics.completeLogTest = function (logFile, expectedLines) {
         jqUnit.fail(err);
     });
 };
+
 /**
  * Test the application metrics - app launches and window times.
  */
@@ -750,7 +752,7 @@ jqUnit.asyncTest("Testing application metrics", function () {
 
 /**
  * Test recordKeyTiming
- * @param theTests
+ * @param {Object} theTests The tests; gpii.tests.metrics.recordKeyTimingKeyTests or typingSessionTests.
  */
 gpii.tests.metrics.recordKeyTimingTests = function (theTests) {
     jqUnit.expect(1);

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -1166,7 +1166,9 @@ jqUnit.asyncTest("Testing version and system info logging", function () {
             data: {
                 "cpu": fluid.VALUE,
                 "cores": /^[1-9][0-9]?$/,
-                "memory": /^[0-9]+\.[0-9]*$/,
+                "memory": /^[0-9]+(\.[0-9]+)?$/,
+                "resolution": /^[0-9]+x[0-9]+$/,
+                "scale": /^[0-9]+(\.[0-9]+)?$/,
                 "osBits": /^(32|64)$/,
                 "osRelease": fluid.VALUE,
                 "osEdition": /Windows/,

--- a/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
+++ b/gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js
@@ -407,6 +407,24 @@ gpii.tests.metrics.inputHookTests = fluid.freezeRecursive([
             data: { keyTime: 0, key: "LEFT" }
         }
     },
+    {   // "system key" (WM_SYSKEYUP is sent when alt is down, should behave the same as WM_KEYUP)
+        input: {
+            nCode: 0,
+            wParam: gpii.windows.API_constants.WM_SYSKEYUP,
+            lParam: {
+                vkCode: gpii.windows.API_constants.virtualKeyCodes.VK_HOME,
+                scanCode: 0,
+                flags: 0,
+                time: 200,
+                dwExtraInfo: 0
+            }
+        },
+        expect: {
+            module: "metrics",
+            event: "key-time",
+            data: { keyTime: 0, key: "HOME" }
+        }
+    },
     // Mouse events
     {   // Click
         input: {
@@ -893,12 +911,56 @@ jqUnit.asyncTest("Testing input metrics: inputHook", function () {
     var expectedLines = [];
     var currentTest = null;
 
-    fluid.each(testData, function (test) {
-        currentTest = test.input;
-        gpii.windows.inputHook(windowsMetrics, currentTest.nCode, currentTest.wParam, currentTest.lParam);
+    var modifiers = [
+        {name: "SHIFT", code: gpii.windows.API_constants.virtualKeyCodes.VK_SHIFT},
+        {name: "CONTROL", code: gpii.windows.API_constants.virtualKeyCodes.VK_CONTROL},
+        {name: "ALT", code: gpii.windows.API_constants.virtualKeyCodes.VK_MENU}
+    ];
 
-        expectedLines.push.apply(expectedLines, fluid.makeArray(test.expect));
+    var expectedModifiers = [];
+
+    // Tests a single element of the test data.
+    var testInput = function () {
+        fluid.each(testData, function (test) {
+            currentTest = test.input;
+            gpii.windows.inputHook(windowsMetrics, currentTest.nCode, currentTest.wParam, currentTest.lParam);
+
+            // insert the modifierKeys field to the expect result, if necessary.
+            var expected = fluid.transform(fluid.makeArray(test.expect), function (expect) {
+                var togo = fluid.copy(expect);
+                if (expectedModifiers.length > 0) {
+                    togo.data.modifierKeys = expectedModifiers;
+                }
+                return togo;
+            });
+
+            expectedLines.push.apply(expectedLines, expected);
+        });
+    };
+
+    // Mock windows.getModifierKeys to return the test data (it's better than simulating the key state)
+    var getModifierKeysOrig = gpii.windows.getModifierKeys;
+    teardowns.push(function () {
+        gpii.windows.getModifierKeys = getModifierKeysOrig;
     });
+
+    gpii.windows.getModifierKeys = function () {
+        return expectedModifiers;
+    };
+
+    // Run all of the input tests, with different combinations of modifier keys pressed.
+    for (var pass = 0; pass < Math.pow(2, modifiers.length); pass++) {
+        expectedModifiers = [];
+        for (var n = 0; n < modifiers.length; n++) {
+            var set = (pass >> n) & 1;
+            if (set) {
+                expectedModifiers.push(modifiers[n].name);
+            }
+        }
+
+        windowsMetrics.startInputMetrics();
+        testInput(expectedModifiers);
+    }
 
     // The events are put in the log in the next tick (to allow the hook handler to return quickly).
     setImmediate(function () {


### PR DESCRIPTION
This adds the following new metrics:
* System info (CPU, Memory, display, windows version)
* GPII versions
* Mouse wheel
* A README file
* The ability to disable mouse/key metrics (eg, if anti-virus complains, or it's too much data).

Updates the following:
* Window activation:
  * logged when it happens, removed duration active (which can be implied).
  * Added window identifier.
  * Using WM_SHELLHOOK notification, rather than polling.
* Modifier key state during key/mouse input.

(no changes to universal)
