### PR TITLE
GPII-2618: Restoring wallpaper after high contrast.

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -18,8 +18,10 @@ https://github.com/GPII/universal/blob/master/LICENSE.txt
 
 "use strict";
 
-var ref = require("ref");
-var ffi = require("ffi-napi");
+var ref = require("ref"),
+    ffi = require("ffi-napi"),
+    fs = require("fs"),
+    path = require("path");
 var fluid = require("gpii-universal");
 
 var gpii = fluid.registerNamespace("gpii");
@@ -472,8 +474,8 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
 };
 
 /**
- * Configures a high-contrast theme, specified from the given .theme file. This setting tells SystemParametersInfo which
- * theme to use.
+ * Saves the current theme, then configures a high-contrast theme, specified from the given .theme file. This setting
+ * tells SystemParametersInfo which theme to use.
  *
  * In the registry, the themes are referred to by their display name. This is identified in the .theme file by the
  * DisplayName value in the [Theme] section.
@@ -484,14 +486,20 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * This function reads this display name from a .theme file, gets the localised name (if required) and sets it in the
  * registry so when SystemParametersInfo is called, the specified theme will be used.
  *
- * @param {String} filename The .theme file, which is in INI file format.
+ * @param {String} newThemeFile The .theme file, which is in INI file format.
+ * @param {String} currentThemeFile The current .theme file, which is in INI file format.
+ * @param {String} saveAs The .theme file to which the current theme is saved.
  * @param {Boolean} dryRun true to not update the registry.
  * @return {String} The display name of the theme specified in the .theme file.
  */
-gpii.windows.spiSettingsHandler.setHighContrastTheme = function (filename, dryRun) {
+gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
+    if (currentThemeFile && saveAs) {
+        gpii.windows.spiSettingsHandler.saveTheme(currentThemeFile, saveAs);
+    }
+
     // The filename may contain environment variables, "%LikeThis%".
-    if (filename.indexOf("%") >= 0) {
-        filename = filename.replace(/%([^%]+)%/g, function (m, name) {
+    if (newThemeFile.indexOf("%") >= 0) {
+        newThemeFile = newThemeFile.replace(/%([^%]+)%/g, function (m, name) {
             return process.env[name] || "";
         });
     }
@@ -499,7 +507,7 @@ gpii.windows.spiSettingsHandler.setHighContrastTheme = function (filename, dryRu
     var themeData;
 
     try {
-        themeData = filename && gpii.iniFile.readFile(filename);
+        themeData = newThemeFile && gpii.iniFile.readFile(newThemeFile);
     } catch (e) {
         fluid.log(e.message);
         themeData = null;
@@ -517,9 +525,74 @@ gpii.windows.spiSettingsHandler.setHighContrastTheme = function (filename, dryRu
     return displayName;
 };
 
+/**
+ * Saves the active changes to the current theme.
+ *
+ * This is needed to be performed before enabling high-contrast because when high-contrast is de-activated it loads
+ * the settings (such as the wallpaper) from the .theme file, rather than the last settings.
+ *
+ * Theme files are described in https://docs.microsoft.com/en-us/windows/desktop/controls/themesfileformat-overview
+ *
+ * @param {String} currentThemeFile The .theme file that's currently being used.
+ * @param {String} saveAs The temporary .theme file to which the current theme is saved.
+ */
+gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) {
+    var themeData = gpii.iniFile.readFile(currentThemeFile);
+    fluid.log("Saving theme from " + currentThemeFile);
+    var isValid = !!(themeData.MasterThemeSelector && themeData.MasterThemeSelector.MTSM);
+    if (!isValid) {
+        fluid.log("Theme file invalid.");
+        // If the theme file isn't valid, load the default one.
+        var defaultTheme = path.join(process.env.SystemRoot, "resources/Themes/aero.theme");
+        if (currentThemeFile !== defaultTheme) {
+            gpii.windows.spiSettingsHandler.saveTheme(defaultTheme);
+        }
+    } else {
+        // Wallpaper
+        var desktop = themeData["Control Panel\\Desktop"];
+        if (!desktop) {
+            desktop = {};
+            themeData["Control Panel\\Desktop"] = desktop;
+        }
+
+        desktop.Wallpaper =
+            gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", "WallPaper", "REG_SZ").value;
+        desktop.TileWallpaper =
+            gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", "TileWallpaper", "REG_SZ").value;
+        desktop.WallpaperStyle =
+            gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", "WallpaperStyle", "REG_SZ").value;
+
+        var backgroundType = gpii.windows.readRegistryKey("HKEY_CURRENT_USER",
+            "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Wallpapers", "BackgroundType", "REG_DWORD").value;
+        if (backgroundType !== 2) {
+            // If it's not a slideshow, then remove the entire section.
+            delete themeData.Slideshow;
+        }
+
+        // Colours
+        var colors = gpii.windows.enumRegistryValues("HKEY_CURRENT_USER", "Control Panel\\Colors");
+        if (!themeData["Control Panel\\Colors"]) {
+            themeData["Control Panel\\Colors"] = {};
+        }
+        fluid.each(colors, function (key) {
+            themeData["Control Panel\\Colors"][key.name] = key.data;
+        });
+
+        // Update the settings from the current theme, saving it into the new file.
+        var iniData = gpii.iniFile.writeFromFile(currentThemeFile, themeData);
+        fs.writeFileSync(saveAs, iniData);
+        // Let Windows know to use this theme file when restoring high-contrast.
+        gpii.windows.writeRegistryKey(
+            "HKEY_CURRENT_USER", "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast",
+            "Pre-High Contrast Scheme", saveAs, "REG_SZ");
+    }
+};
+
 fluid.defaults("gpii.windows.spiSettingsHandler.setHighContrastTheme", {
     gradeNames: "fluid.function",
     argumentMap: {
-        filename: 0
+        newTheme: 0,
+        currentTheme: 1,
+        saveAs: 2
     }
 });

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -21,7 +21,8 @@ https://github.com/GPII/universal/blob/master/LICENSE.txt
 var ref = require("ref"),
     ffi = require("ffi-napi"),
     fs = require("fs"),
-    path = require("path");
+    path = require("path"),
+    mkdirp = require("mkdirp");
 var fluid = require("gpii-universal");
 
 var gpii = fluid.registerNamespace("gpii");
@@ -580,6 +581,8 @@ gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) 
 
         // Update the settings from the current theme, saving it into the new file.
         var iniData = gpii.iniFile.writeFromFile(currentThemeFile, themeData);
+        var directory = path.dirname(saveAs);
+        mkdirp.sync(directory);
         fs.writeFileSync(saveAs, iniData);
         // Let Windows know to use this theme file when restoring high-contrast.
         gpii.windows.writeRegistryKey(

--- a/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/test/testSpiSettingsHandler.js
@@ -20,7 +20,9 @@
 var fluid = require("gpii-universal"),
     jqUnit = fluid.require("node-jqunit"),
     gpii = fluid.registerNamespace("gpii"),
-    $ = fluid.registerNamespace("jQuery");
+    $ = fluid.registerNamespace("jQuery"),
+    path = require("path"),
+    os = require("os");
 
 require("../src/SpiSettingsHandler.js");
 
@@ -128,9 +130,67 @@ jqUnit.test("Testing setHighContrastTheme", function () {
     // See what the setHighContrastTheme returns.
     fluid.each(highContrastThemes, function (test) {
         var file = test.file.replace("%SystemRoot%", process.env.SystemRoot);
-        var result = gpii.windows.spiSettingsHandler.setHighContrastTheme(file, true);
+        var result = gpii.windows.spiSettingsHandler.setHighContrastTheme(file, null, null, true);
 
         jqUnit.assertEquals("setHighContrastTheme must return the expected result, file=" + file, test.expect, result);
 
     });
+});
+jqUnit.test("Testing saveTheme", function () {
+
+    var currentTheme = "C:\\Windows\\Resources\\Themes\\aero.theme";
+    var tempTheme = path.join(os.tmpdir(), "gpii-test.theme");
+
+    var desktopRestore = {};
+
+    var desktopTest = {
+        Wallpaper: "test value for Wallpaper",
+        TileWallpaper: "test value for TileWallpaper",
+        WallpaperStyle: "test value for WallpaperStyle"
+    };
+
+    var preContrastRestore = gpii.windows.readRegistryKey(
+        "HKEY_CURRENT_USER", "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast",
+        "Pre-High Contrast Scheme", "REG_SZ").value;
+
+    try {
+
+        // Set the settings that the saveTheme() saves.
+        fluid.each(desktopTest, function (value, key) {
+            // Save the value, for restoration.
+            desktopRestore[key] =
+                gpii.windows.readRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", key, "REG_SZ").value;
+            // Set it to something different.
+            gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", key, value, "REG_SZ");
+        });
+
+        gpii.windows.spiSettingsHandler.saveTheme(currentTheme, tempTheme);
+
+        // Check the settings have been stored to the file
+        var themeData = gpii.iniFile.readFile(tempTheme);
+
+        var desktop = themeData["Control Panel\\Desktop"];
+        jqUnit.assertTrue(".theme file should contain the desktop section", !!desktop);
+
+        fluid.each(desktopTest, function (value, key) {
+            jqUnit.assertEquals("The " + key + " setting must be what was written", value, desktop[key]);
+        });
+
+
+        var preContrast = gpii.windows.readRegistryKey(
+            "HKEY_CURRENT_USER", "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast",
+            "Pre-High Contrast Scheme", "REG_SZ").value;
+        jqUnit.assertEquals("'Pre-High Contrast Scheme' should be set to the new file", tempTheme, preContrast);
+
+    } finally {
+        // Restore the registry
+        gpii.windows.writeRegistryKey(
+            "HKEY_CURRENT_USER", "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast",
+            "Pre-High Contrast Scheme", preContrastRestore, "REG_SZ");
+
+        fluid.each(desktopRestore, function (value, key) {
+            gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Desktop", key, value, "REG_SZ");
+        });
+
+    }
 });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "edge-js": "10.3.1",
         "ffi-napi": "2.4.3",
-        "gpii-universal": "0.3.0-dev.20181030T224346Z.f99c27bb",
+        "gpii-universal": "stegru/universal#GPII-2618",
         "@pokusew/pcsclite": "0.4.18",
         "ref": "1.3.4",
         "ref-struct": "1.1.0",


### PR DESCRIPTION
To test:

* Change the wallpaper
* Key-in with high-contrast (`snapset_2a`)
* Wallpaper goes
* Key-out
* The wallpaper should be the same as what it was before key-in (before this fix, it was the default wallpaper).

Requires https://github.com/GPII/universal/pull/710