### PR TITLE
GPII-3501: Fix high-contrast + language combination

### DIFF
--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -381,7 +381,7 @@ gpii.windows.restartExplorer = function (options) {
             var p = fluid.promise();
             gpii.windows.waitForProcessStart("sethc.exe", {timeout: 1000}).then(function () {
                 fluid.promise.follow(gpii.windows.waitForProcessTermination("sethc.exe", {timeout: 5000}), p);
-            }, p.reject);
+            }, p.resolve);
             return p;
         },
         gpii.windows.stopExplorer,

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -323,6 +323,8 @@ gpii.windows.stopExplorer = function (options) {
     }, options);
     var promise = fluid.promise();
 
+    fluid.log("Stopping explorer");
+
     // The tasktray handles a window message of 0x5b4 which causes it to save state and shutdown.
     // See https://stackoverflow.com/questions/5689904/gracefully-exit-explorer-programmatically
     var closeExplorerMessage = gpii.windows.API_constants.WM_USER + 0x1b4;
@@ -330,8 +332,8 @@ gpii.windows.stopExplorer = function (options) {
     var trayWindow = options.trayWindow || windows.getTasktrayWindow();
     var pid;
     if (trayWindow) {
-        windows.user32.PostMessageW(trayWindow, closeExplorerMessage, 0, 0);
         pid = windows.getWindowProcessId(trayWindow);
+        windows.user32.PostMessageW(trayWindow, closeExplorerMessage, 0, 0);
     }
 
     if (pid) {
@@ -367,21 +369,37 @@ gpii.windows.restartExplorer = function (options) {
         args: ["/LOADSAVEDWINDOWS"]
     }, options);
 
-    var promiseTogo = fluid.promise();
+    // Hide the taskbar, in case someone tries to interact with it just before it restarts.
+    var trayWindow = options.trayWindow || windows.getTasktrayWindow();
+    if (trayWindow) {
+        gpii.windows.user32.ShowWindow(trayWindow, 0);
+    }
 
-    gpii.windows.stopExplorer(options).then(function () {
-        var child = child_process.spawn(options.explorer, options.args, {
-            detached: true,
-            stdio: "ignore"
-        });
-        child.on("error", function (err) {
-            fluid.log("Error starting explorer:", err);
-        });
+    var work = [
+        function () {
+            // Don't restart explorer if high-contrast is currently being applied.
+            var p = fluid.promise();
+            gpii.windows.waitForProcessStart("sethc.exe", {timeout: 1000}).then(function () {
+                fluid.promise.follow(gpii.windows.waitForProcessTermination("sethc.exe", {timeout: 5000}), p);
+            }, p.reject);
+            return p;
+        },
+        gpii.windows.stopExplorer,
+        function () {
+            fluid.log("Starting explorer");
+            var child = child_process.spawn(options.explorer, options.args, {
+                detached: true,
+                stdio: "ignore"
+            });
+            child.on("error", function (err) {
+                fluid.log("Error starting explorer:", err);
+            });
 
-        fluid.promise.follow(windows.waitForCondition(windows.getTasktrayWindow, {timeout:30000}), promiseTogo);
-    });
+            return windows.waitForCondition(windows.getTasktrayWindow, {timeout: options.timeout});
+        }
+    ];
 
-    return promiseTogo;
+    return fluid.promise.sequence(work, options);
 };
 
 /**

--- a/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
+++ b/gpii/node_modules/windowsMetrics/src/windowsMetrics.js
@@ -316,7 +316,7 @@ windows.metrics.stopApplicationMetrics = function (that) {
  * @param {Component} that The gpii.windowsMetrics instance.
  */
 windows.metrics.logAppActivate = function (that) {
-    if (that.state.application.currentProcess) {
+    if (that.state.application.currentProcess && that.state.application.currentProcess.pid) {
         var data = {
             exe: that.state.application.currentProcess.exe,
             window: that.state.application.currentProcess.pid.toString(36) + "-"


### PR DESCRIPTION
When changing the language and high-contrast at the same time, the wallpaper and colours sometimes did not get applied, or where half applied.

It might be best to wait for https://github.com/GPII/windows/pull/217.

This change makes it wait until the high-contrast has finished doing its thing before restarting explorer.

To test:
- Key in with a different language and high-contrast (`226722c6-8895-40b4-9297-424b9da9c340`, I think)
- The desktop should be black, colours correct for high-contrast.
- Key out
- Desktop wallpaper should return, and colours applied correctly.
