### PR TITLE
GPII-3543: Waiting for resolution to be applied before testing DPI.

### DIFF
--- a/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
+++ b/gpii/node_modules/displaySettingsHandler/test/testDisplaySettingsHandler.js
@@ -166,38 +166,65 @@ jqUnit.test("Testing getScreenDpi ", function () {
 });
 
 // This test is only able to test the implementation for the version of Windows it's running on.
-jqUnit.test("Testing setScreenDpi ", function () {
+jqUnit.asyncTest("Testing setScreenDpi ", function () {
+    var resolutionPromise;
+
     // Make sure the resolution is good enough to have DPI above 100%. 1024x768 provides up to 125%.
+    var minRes = {
+        width: 1024,
+        height: 768
+    };
     var res = gpii.windows.display.getScreenResolution();
-    if (res.width < 1024 || res.height < 768) {
+    fluid.log("Current resolution:", res);
+
+    if (res.width < minRes.width || res.height < minRes.height) {
+        fluid.log("Increasing resolution for DPI tests.");
         teardowns.push(function () {
             gpii.windows.display.setScreenResolution(res);
         });
 
-        gpii.windows.display.setScreenResolution({width: 1024, height: 768});
+        gpii.windows.display.setScreenResolution(minRes);
+
+        // Wait for the change to be applied.
+        resolutionPromise = gpii.windows.waitForCondition(function () {
+            var current = gpii.windows.display.getScreenResolution();
+            return current.width === minRes.width && current.height === minRes.height;
+        }, {timeout:10000, dontReject:true});
+    } else {
+        resolutionPromise = fluid.promise().resolve();
     }
 
-    // Restore the original setting at the end.
-    var originalDpi = gpii.windows.display.getScreenDpi();
-    teardowns.push(function () {
-        gpii.windows.display.setScreenDpi(originalDpi.configured);
+    resolutionPromise.then(function (value) {
+        if (value === "timeout") {
+            fluid.log("Timed out waiting for resolution change.");
+        }
+
+        // Restore the original setting at the end.
+        var originalDpi = gpii.windows.display.getScreenDpi();
+        teardowns.push(function () {
+            gpii.windows.display.setScreenDpi(originalDpi.configured);
+        });
+
+        fluid.log("Start dpi: ", originalDpi);
+
+        // Set it to the current setting
+        var dpi = gpii.windows.display.setScreenDpi(originalDpi.configured);
+        var currentDpi = gpii.windows.display.getScreenDpi();
+        jqUnit.assertDeepEq("get/setScreenDpi should return the same", dpi, currentDpi);
+
+        var tests = gpii.tests.displaySettings.resolveReferences({
+            minimum: originalDpi.minimum,
+            maximum: originalDpi.maximum,
+            overMaximum: Math.ceil(originalDpi.maximum + 1)
+        }, gpii.tests.displaySettings.dpiTestDefs);
+
+        for (var index = 0; index < tests.length; index++) {
+            var testData = tests[index];
+            var actual = gpii.windows.display.setScreenDpi(testData.input);
+
+            jqUnit.assertDeepEq("setScreenDpi " + testData.input, testData.expected, actual);
+        }
+
+        jqUnit.start();
     });
-
-    // Set it to the current setting
-    var dpi = gpii.windows.display.setScreenDpi(originalDpi.configured);
-    var currentDpi = gpii.windows.display.getScreenDpi();
-    jqUnit.assertDeepEq("get/setScreenDpi should return the same", dpi, currentDpi);
-
-    var tests = gpii.tests.displaySettings.resolveReferences({
-        minimum: originalDpi.minimum,
-        maximum: originalDpi.maximum,
-        overMaximum: Math.ceil(originalDpi.maximum + 1)
-    }, gpii.tests.displaySettings.dpiTestDefs);
-
-    for (var index = 0; index < tests.length; index++) {
-        var testData = tests[index];
-        var actual = gpii.windows.display.setScreenDpi(testData.input);
-
-        jqUnit.assertDeepEq("setScreenDpi " + testData.input, testData.expected, actual);
-    }
 });


### PR DESCRIPTION
This should fix one of the failures in GPII-3528, by waiting for the resolution to change before testing the DPI.

Unfortunately, it's another one of those random/timing issues which depend on the wind direction.

```
15:53:25.832:  jq: FAIL: Module "Windows Display Settings Handler Tests" Test name "Testing setScreenDpi " - Message: setScreenDpi -1
15:53:25.832: jq: Expected: { "actual": -1, "configured": -1, "minimum": 0, "maximum": 1 }
15:53:25.832: jq: Actual: { "configured": -1, "minimum": 0, "maximum": 0, "actual": -1 } 
```