### PR TITLE
NOJIRA: Fix crash in tests when running with electron

### DIFF
--- a/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/src/RegistrySettingsHandler.js
@@ -436,8 +436,8 @@ windows.writeUwpSecurity = function (keyHolder) {
     var information = windows.securityInformation.DACL_SECURITY_INFORMATION;
     var secBuffer = windows.regGetKeySecurity(keyHolder, information);
 
-    var isPresent = Buffer.alloc(1);
-    var isDefaulted = Buffer.alloc(1);
+    var isPresent = Buffer.alloc(4);
+    var isDefaulted = Buffer.alloc(4);
 
     var oldACL = windows.getSecurityDescriptorDacl(secBuffer, isPresent, isDefaulted);
 

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -491,8 +491,8 @@ jqUnit.test("Testing UWP key permissions", function () {
         windows.openRegistryKey(baseKey, path, keyHolder, true);
 
         var secBuffer = windows.regGetKeySecurity(keyHolder, information);
-        var isPresent = Buffer.alloc(1);
-        var isDefaulted = Buffer.alloc(1);
+        var isPresent = Buffer.alloc(4);
+        var isDefaulted = Buffer.alloc(4);
 
         var oldACL = windows.getSecurityDescriptorDacl(secBuffer, isPresent, isDefaulted);
 

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -462,7 +462,7 @@ var ffi = require("ffi-napi"),
     ref = require("ref");
 
 var advapi32 = new ffi.Library("advapi32", {
-    GetExplicitEntriesFromAclA: [
+    GetExplicitEntriesFromAclW: [
         "uint32", ["void*", "uint32*", "void*"]
     ],
     LookupAccountSidW: [
@@ -499,7 +499,7 @@ jqUnit.test("Testing UWP key permissions", function () {
         var entriesBuff = Buffer.alloc(4);
         var eaRef = Buffer.alloc(ref.sizeof.pointer);
 
-        advapi32.GetExplicitEntriesFromAclA(oldACL.deref(), entriesBuff, eaRef);
+        advapi32.GetExplicitEntriesFromAclW(oldACL.deref(), entriesBuff, eaRef);
 
         var entries = entriesBuff.readUInt32LE();
         var foundCorrectPermission = false;


### PR DESCRIPTION
I think the problem was that the ANSI version of GetExplicitEntriesFromAcl was being used, instead of the unicode one - or at least, changing it stops the crash.

There is another fix where some buffers allocated just 1 byte for a boolean. This caused a couple of buffer overruns, but no crash.