### PR TITLE
Fixes test crash in electron

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -137,7 +137,7 @@ windows.kernel32 = ffi.Library("kernel32", {
     ],
     // https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-localfree
     "LocalFree": [
-        "uint32", [ "void*" ]
+        "uint32", [ "int" ]
     ],
     // https://docs.microsoft.com/windows/desktop/api/winnls/nf-winnls-getthreaduilanguage
     "GetThreadUILanguage": [

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -497,7 +497,7 @@ jqUnit.test("Testing UWP key permissions", function () {
         var oldACL = windows.getSecurityDescriptorDacl(secBuffer, isPresent, isDefaulted);
 
         var entriesBuff = Buffer.alloc(4);
-        var eaRef = Buffer.alloc(ref.sizeof.pointer);
+        var eaRef = ref.alloc("int");
 
         advapi32.GetExplicitEntriesFromAclW(oldACL.deref(), entriesBuff, eaRef);
 
@@ -532,7 +532,7 @@ jqUnit.test("Testing UWP key permissions", function () {
         }
         jqUnit.assertDeepEq("Correct permissions where found into modified key", true, foundCorrectPermission);
 
-        windows.kernel32.LocalFree(eaRef);
+        windows.kernel32.LocalFree(eaRef.deref());
     } catch (e) {
         jqUnit.fail("Checking registry key permissions failed with error message: " + e.message);
     } finally {

--- a/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
+++ b/gpii/node_modules/registrySettingsHandler/test/testRegistrySettingsHandler.js
@@ -533,8 +533,6 @@ jqUnit.test("Testing UWP key permissions", function () {
         jqUnit.assertDeepEq("Correct permissions where found into modified key", true, foundCorrectPermission);
 
         windows.kernel32.LocalFree(eaRef.deref());
-    } catch (e) {
-        jqUnit.fail("Checking registry key permissions failed with error message: " + e.message);
     } finally {
         windows.closeRegistryKey(keyHolder);
         gpii.windows.deleteRegistryKey("HKEY_CURRENT_USER", "Software\\GPIIMagnifier");


### PR DESCRIPTION
The pointer was being freed, rather than the memory it points to.

Testing in https://github.com/GPII/gpii-app/pull/72
