### PR TITLE
GPII-3558: Closing explorer folder windows when restarting explorer.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -253,6 +253,10 @@ windows.user32 = ffi.Library("user32", {
     "SendMessageW": [
         "int", [t.HANDLE, t.UINT, t.UINT, "int" ]
     ],
+    // https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-sendmessagecallbackw
+    "SendMessageCallbackW": [
+        "int", [t.HANDLE, t.UINT, t.UINT, "int", "void*", t.ULONG_PTR ]
+    ],
     // https://msdn.microsoft.com/library/ms633519
     "GetWindowRect": [
         t.BOOL, [ t.HANDLE, t.PVOID ]
@@ -423,6 +427,10 @@ windows.API_constants = {
     TRUE:   1,
     // https://msdn.microsoft.com/library/windows/desktop/ms632641
     WM_QUIT: 0x12,
+    // https://docs.microsoft.com/windows/desktop/shutdown/wm-queryendsession
+    WM_QUERYENDSESSION: 0x11,
+    // https://docs.microsoft.com/windows/desktop/shutdown/wm-endsession
+    WM_ENDSESSION: 0x16,
     // https://msdn.microsoft.com/library/ms912654
     WM_KEYDOWN: 0x100,
     // https://msdn.microsoft.com/library/ms646281
@@ -1433,6 +1441,41 @@ windows.getTopParent = function (hwnd) {
     }
 
     return togo;
+};
+
+/**
+ * Finds all windows with the given class name.
+ *
+ * @param {String|Array<String>} className The window class, or an array describing the path to a class (starting at the
+ * top-level parent), used to find child windows.
+ * @param {Number} parent [optional] The parent handle from which the search begins.
+ * @return {Array<String>} The window handles of the matching windows.
+ */
+windows.findWindows = function (className, parent) {
+    var path = fluid.makeArray(className);
+
+    var windowClass = path.shift();
+
+    var classBuffer = Buffer.alloc(0xff);
+    classBuffer.ref().fill(0);
+
+    // Get the window that has the specified class
+    var matches = [];
+    windows.enumerateWindows(parent, function (hwndFound) {
+        if (windows.user32.GetClassNameW(hwndFound, classBuffer, classBuffer.length)) {
+            var cls = windows.stringFromWideChar(classBuffer);
+            if (cls === windowClass) {
+                if (path.length > 0) {
+                    var child = windows.findWindows(path, hwndFound);
+                    matches.push.apply(matches, child);
+                } else {
+                    matches.push(hwndFound);
+                }
+            }
+        }
+    });
+
+    return matches;
 };
 
 /**

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -19,7 +19,8 @@
 
 var fluid = require("gpii-universal");
 var ref = require("ref"),
-    child_process = require("child_process");
+    child_process = require("child_process"),
+    path = require("path");
 
 var gpii = fluid.registerNamespace("gpii");
 var windows = fluid.registerNamespace("gpii.windows");
@@ -162,6 +163,7 @@ gpii.windows.isProcessRunning = function (proc) {
  * @param {Boolean} options.start The desired state: true to wait for the process to start, false to wait for the termination.
  * @param {Number} options.timeout Approximate milliseconds to wait, or null for infinite.
  * @param {Number} options.pollDelay How long to wait, in milliseconds, between checking for the process.
+ * @param {Boolean} options.dontReject If true, then resolve the promise with "timeout" instead of rejecting.
  * @return {Promise} The promise will resolve when the process is in the desired state, or will reject if after the
  *   timeout the process is still in the same state.
  */
@@ -179,6 +181,7 @@ gpii.windows.waitForProcessState = function (proc, options) {
         conditionValue: options.start,
         pollDelay: options.pollDelay,
         timeout: options.timeout,
+        dontReject: options.dontReject,
         error: {
             isError: true,
             message: "Timed out waiting for process " + proc +
@@ -198,6 +201,7 @@ gpii.windows.waitForProcessState = function (proc, options) {
  * @param {Object} userOptions The options.
  * @param {Number} userOptions.timeout Approximate milliseconds to wait, or null for infinite.
  * @param {Number} userOptions.pollDelay How long to wait, in milliseconds, between checking for the process.
+ * @param {Boolean} userOptions.dontReject If true, then resolve the promise with "timeout" instead of rejecting.
  * @return {Promise} The promise will resolve when there are no matching processes running, or will reject if a matching
  *  process is still running after the timeout.
  */
@@ -215,6 +219,7 @@ gpii.windows.waitForProcessTermination = function (proc, userOptions) {
  * @param {Object} userOptions The options.
  * @param {Number} userOptions.timeout Approximate milliseconds to wait, or null for infinite.
  * @param {Number} userOptions.pollDelay How long to wait, in milliseconds, between checking for the process.
+ * @param {Boolean} userOptions.dontReject If true, then resolve the promise with "timeout" instead of rejecting.
  * @return {Promise} The promise will resolve when there is a matching processes running, or will reject if a matching
  *  process is still not running after the timeout.
  */
@@ -386,44 +391,78 @@ gpii.windows.getExplorerProcess = function () {
 };
 
 /**
- * Stops the Windows Explorer shell process.
+ * Stops the Windows Explorer shell process, including the folder windows.
  *
  * Use restartExplorer() to restart it.
  *
  * @param {Object} options [optional] Options object.
  * @param {Number} options.trayWindow Override the task tray's window handle.
- * @param {Number} options.timeout Timeout, in ms, to wait before forcefully terminating the process [default: 6000].
+ * @param {Boolean} options.ignoreFolders True to keep the folder windows open [default: false].
+ * @param {Number} options.timeout Timeout, in ms, to wait before forcefully terminating the process [default: 8000].
+ * @param {String} options.explorerExe The explorer executable name to kill [default: explorer.exe]
  * @return {Promise} Resolves when explorer has stopped.
  */
 gpii.windows.stopExplorer = function (options) {
     options = Object.assign({
         trayWindow: null,
-        timeout: 6000
+        ignoreFolders: false,
+        timeout: 8000,
+        explorerExe: "explorer.exe"
     }, options);
     var promise = fluid.promise();
 
     fluid.log("Stopping explorer");
 
-    // The tasktray handles a window message of 0x5b4 which causes it to save state and shutdown.
-    // See https://stackoverflow.com/questions/5689904/gracefully-exit-explorer-programmatically
-    var closeExplorerMessage = gpii.windows.API_constants.WM_USER + 0x1b4;
+    if (gpii.windows.isProcessRunning(options.explorerExe)) {
 
-    var trayWindow = options.trayWindow || windows.getTasktrayWindow();
-    var pid;
-    if (trayWindow) {
-        pid = windows.getWindowProcessId(trayWindow);
-        windows.user32.PostMessageW(trayWindow, closeExplorerMessage, 0, 0);
-    }
+        // The tasktray handles a window message of 0x5b4 which causes it to save state and shutdown.
+        // See https://stackoverflow.com/questions/5689904/gracefully-exit-explorer-programmatically
+        var closeExplorerMessage = gpii.windows.API_constants.WM_USER + 0x1b4;
 
-    if (pid) {
-        // The process has been known to linger, preventing a new one. Give it a few seconds, then be more forceful.
-        windows.waitForProcessTermination(pid, {timeout: options.timeout}).then(promise.resolve, function () {
+        var trayWindow = options.trayWindow || windows.getTasktrayWindow();
+
+        // The folder windows also need to be closed, otherwise future ones will have a mixture of languages.
+        var explorerWindows = options.ignoreFolders ? [] : windows.findWindows("CabinetWClass");
+
+        var closeTrayPromise;
+        if (trayWindow) {
+            windows.user32.PostMessageW(trayWindow, closeExplorerMessage, 0, 0);
+
+            // Unable to completely make explorer terminate without killing it, so WM_ENDSESSION is being sent so explorer
+            // should at least expect to be killed.
+            windows.user32.PostMessageW(trayWindow, windows.API_constants.WM_QUERYENDSESSION, 0, 1);
+            closeTrayPromise = gpii.windows.messages.sendMessageAsync(trayWindow, windows.API_constants.WM_ENDSESSION,
+                1, 1, options.timeout);
+        } else {
+            closeTrayPromise = fluid.promise().resolve();
+        }
+
+        // Also instruct the folder windows to shutdown. Sending WM_QUERYENDSESSION causes the windows to re-appear when
+        // explorer is restarted.
+        fluid.each(explorerWindows, function (window) {
+            windows.user32.PostMessageW(window, windows.API_constants.WM_QUERYENDSESSION, 0, 1);
+            windows.user32.PostMessageW(window, windows.API_constants.WM_ENDSESSION, 1, 1);
+        });
+
+        // Wait for the tray to process the shutdown message.
+        closeTrayPromise.then(function (value) {
+            if (value === "timeout") {
+                fluid.log("Explorer did not respond to shutdown request");
+            } else {
+                fluid.log("Explorer processed shutdown");
+                // Explorer now expects to be killed
+                windows.killProcessByName(options.explorerExe);
+            }
+        });
+
+        // The process has been known to linger, preventing a new instance. Give it until the timeout, then be more forceful
+        windows.waitForProcessTermination(options.explorerExe, {timeout: options.timeout}).then(promise.resolve, function () {
             fluid.log("Explorer did not close - terminating");
-            process.kill(pid);
+            windows.killProcessByName(options.explorerExe);
             promise.resolve();
         });
     } else {
-        fluid.log("Explorer process not found");
+        // Explorer was not running.
         promise.resolve();
     }
 
@@ -437,16 +476,23 @@ gpii.windows.stopExplorer = function (options) {
  *
  * @param {Object} options Options.
  * @param {String} options.explorer Path to the explorer executable [default: %SystemRoot%\explorer.exe]
+ * @param {String} options.explorerExe Executable name of explorer [default: taken from options.explorer]
  * @param {Number} options.trayWindow Override the task tray's window handle.
  * @param {Number} options.timeout Timeout, in ms, to wait before forcefully terminating the process.
  * @param {Array<String>} options.args Arguments to pass to explorer
  * @return {Promise} Resolves when explorer has restarted.
  */
 gpii.windows.restartExplorer = function (options) {
-    options = Object.assign({
-        explorer: process.env.SystemRoot + "\\explorer.exe",
-        args: ["/LOADSAVEDWINDOWS"]
-    }, options);
+    options = Object.assign({}, options);
+
+    if (!options.explorer) {
+        options.explorer = process.env.SystemRoot + "\\explorer.exe";
+        options.args = ["/LOADSAVEDWINDOWS"];
+    }
+
+    if (!options.explorerExe) {
+        options.explorerExe = path.basename(options.explorer);
+    }
 
     // Hide the taskbar, in case someone tries to interact with it just before it restarts.
     var trayWindow = options.trayWindow || windows.getTasktrayWindow();
@@ -456,7 +502,7 @@ gpii.windows.restartExplorer = function (options) {
 
     var work = [
         function () {
-            // Don't restart explorer if high-contrast is currently being applied.
+            // Don't restart explorer while high-contrast is currently being applied.
             var p = fluid.promise();
             gpii.windows.waitForProcessStart("sethc.exe", {timeout: 1000}).then(function () {
                 fluid.promise.follow(gpii.windows.waitForProcessTermination("sethc.exe", {timeout: 5000}), p);
@@ -464,6 +510,10 @@ gpii.windows.restartExplorer = function (options) {
             return p;
         },
         gpii.windows.stopExplorer,
+        function () {
+            // Wait for explorer to completely close.
+            return windows.waitForProcessTermination(options.explorerExe, {timeout: 1000, dontReject: true});
+        },
         function () {
             fluid.log("Starting explorer");
             var child = child_process.spawn(options.explorer, options.args, {

--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -269,11 +269,11 @@ jqUnit.asyncTest("Testing stopExplorer", function () {
     var child = child_process.exec(command, function (error) {
         fluid.log("Exit code:", error.code);
 
-        jqUnit.assertEquals("Exit code", 1, error.code);
-        if (error.code !== 1) {
+        jqUnit.assertEquals("Exit code", 5, error.code);
+        if (error.code !== 5) {
             jqUnit.fail();
         } else {
-            // This test shouldn't have stopped explorer.
+            // This test shouldn't have stopped the real explorer.
             jqUnit.assertTrue("Explorer should still be running.", gpii.windows.getExplorerProcess());
 
             jqUnit.start();
@@ -288,7 +288,12 @@ jqUnit.asyncTest("Testing stopExplorer", function () {
             // Window was created - get the handle.
             var testWindow = match[1];
 
-            var p = gpii.windows.stopExplorer({trayWindow: testWindow, timeout: 1000});
+            var p = gpii.windows.stopExplorer({
+                trayWindow: testWindow,
+                timeout: 1000,
+                ignoreFolders: true,
+                explorerExe: exeName
+            });
 
             jqUnit.assertTrue("stopExplorer should return a promise", fluid.isPromise(p));
 
@@ -318,13 +323,13 @@ jqUnit.asyncTest("Testing restartExplorer", function () {
         gpii.windows.killProcessByName(exeName);
     });
 
-    // Setting trayWindow to INVALID_HANDLE_VALUE will make stopExplorer think explorer isn't running and resolve
-    // without doing anything.
+    // Setting trayWindow to INVALID_HANDLE_VALUE will prevent restartExplorer from hiding the real taskbar.
     var INVALID_HANDLE_VALUE = 0xffffffff;
     var restartPromise = gpii.windows.restartExplorer({
         trayWindow: INVALID_HANDLE_VALUE,
         explorer: exePath,
-        args: [ "-window" ]
+        args: [ "-window" ],
+        ignoreFolders: true
     });
 
     jqUnit.assertTrue("restartExplorer should return a promise", fluid.isPromise(restartPromise));

--- a/gpii/node_modules/windowMessages/src/windowMessages.js
+++ b/gpii/node_modules/windowMessages/src/windowMessages.js
@@ -255,4 +255,47 @@ gpii.windows.messages.destroyMessageWindow = function (that) {
     return success;
 };
 
+/**
+ * Send a message to a window, returning a promise which resolve when the message has been processed.
+ *
+ * @param {Number} hwnd The window handle.
+ * @param {Number} msg The message, or the name of a registered message (will be registered if not already).
+ * @param {Number} wParam Message parameter.
+ * @param {Number} lParam Message parameter.
+ * @param {Number} timeout [optional] Number of milliseconds to wait before resolving with "timeout".
+ * @return {Promise} Resolves when the message has been processed.
+ */
+gpii.windows.messages.sendMessageAsync = function (hwnd, msg, wParam, lParam, timeout) {
+    var promise = fluid.promise();
+    var complete = false;
+
+    var timer = timeout && setTimeout(function () {
+        if (!complete) {
+            complete = true;
+            promise.resolve("timeout");
+        }
+    }, timeout);
+
+    var t = gpii.windows.types;
+    var callback = ffi.Callback(t.BOOL, [t.HANDLE, t.UINT, t.UINT, t.ULONG_PTR, t.ULONG_PTR],
+        function (w, m, wp, lp, result) {
+            if (!complete) {
+                complete = true;
+                promise.resolve(result);
+            }
+            if (timer) {
+                clearTimeout(timer);
+            }
+        });
+
+    gpii.windows.user32.SendMessageCallbackW(hwnd, msg, wParam, lParam, callback, 0);
+
+    // Keep the callback alive for as long as the promise.
+    promise.then(function () {
+        return callback && null;
+    });
+
+    return promise;
+};
+
 gpii.windows.messages();

--- a/gpii/node_modules/windowMessages/src/windowMessages.js
+++ b/gpii/node_modules/windowMessages/src/windowMessages.js
@@ -290,8 +290,12 @@ gpii.windows.messages.sendMessageAsync = function (hwnd, msg, wParam, lParam, ti
 
     gpii.windows.user32.SendMessageCallbackW(hwnd, msg, wParam, lParam, callback, 0);
 
-    // Keep the callback alive for as long as the promise.
+    // SendMessageCallbackW is async, and will call the callback function beyond the lifetime of this function. This
+    // has meant that callback sometimes gets GC'd before it is called. Referring to it in a function that's attached
+    // to the promise will keep the callback alive for as long as the promise.
+    // https://github.com/node-ffi/node-ffi/issues/72#issuecomment-8599403
     promise.then(function () {
+        // A no-op that keeps a reference to callback.
         return callback && null;
     });
 


### PR DESCRIPTION
This should fix the issue where *explorer* is showing a mixture of languages. It ensures that all folder windows are also closed (they should also re-appear).
