### PR TITLE
GPII-3605: Correcting language code casing

### DIFF
--- a/gpii/node_modules/gpii-localisation/src/language.js
+++ b/gpii/node_modules/gpii-localisation/src/language.js
@@ -80,6 +80,36 @@ fluid.defaults("gpii.windows.language", {
  */
 
 /**
+ * Fixes the casing of a language code, so the language is lowercase and the region is uppercase.
+ *
+ * @param {String} langCode The language code.
+ * @return {String} The language code, in the correct casing.
+ */
+gpii.windows.language.fixCodeCase = function (langCode) {
+    var parts = (langCode && langCode.split) ? langCode.split("-") : [];
+
+    // [RFC-5646] Language is always the first section - "2*3ALPHA ; shortest ISO 639 code"
+    if (parts.length > 0 && (parts[0].length === 2 || parts[0].length === 3)) {
+        parts[0] = parts[0].toLowerCase();
+
+        // [RFC-5646] describes a language tag as having a varying number of sections before and after the region. The
+        // region is the only section after the language that is 2 letters (may also be 3 digits, but for casing that's
+        // irrelevant)
+        var region;
+        for (var n = 1; n < parts.length; n++) {
+            if (parts[n].length === 2) {
+                region = n;
+            }
+        }
+
+        if (region) {
+            parts[region] = parts[region].toUpperCase();
+        }
+    }
+
+    return parts.join("-");
+};
+/**
  * Gets the display languages that are installed on the system, and updates the model.
  *
  * These are listed in HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\MUI\UILanguages
@@ -91,6 +121,8 @@ fluid.defaults("gpii.windows.language", {
 gpii.windows.language.getInstalled = function (that) {
     var langCodes = gpii.windows.enumRegistryKeys(
         "HKEY_LOCAL_MACHINE", "SYSTEM\\CurrentControlSet\\Control\\MUI\\UILanguages");
+
+    langCodes = langCodes.map(gpii.windows.language.fixCodeCase);
 
     var current = gpii.windows.language.getDisplayLanguage();
 
@@ -260,7 +292,7 @@ gpii.windows.language.getDisplayLanguage = function () {
             fluid.log(gpii.windows.win32errorText("LCIDToLocaleName failed", result));
         }
     }
-    return langCode;
+    return gpii.windows.language.fixCodeCase(langCode);
 };
 
 /**

--- a/gpii/node_modules/gpii-localisation/test/testLanguage.js
+++ b/gpii/node_modules/gpii-localisation/test/testLanguage.js
@@ -30,6 +30,92 @@ require("../src/language.js");
 fluid.registerNamespace("gpii.tests.windows.language");
 
 // Tests for getLanguageNames();
+// Language code casing tests (from https://tools.ietf.org/html/rfc5646#appendix-A)
+// expected => [inputs]
+gpii.tests.windows.language.codeCaseTests = fluid.freezeRecursive({
+    // Simple language subtag:
+    "de": ["de", "DE"],
+    // Language subtag plus Script subtag:
+    "zh-Hant": ["zh-Hant", "ZH-Hant"],
+    // Extended language subtags and their primary language subtag counterparts
+    "zh-cmn-Hans-CN": ["zh-cmn-Hans-cn", "ZH-cmn-Hans-CN"],
+    "cmn-Hans-CN": ["cmn-Hans-cn", "CMN-Hans-CN"],
+    "yue-HK": ["yue-hk", "YUE-HK"],
+    "yue": ["yue", "YUE"],
+
+    // Language-Script-Region:
+    "sr-Latn-RS": ["sr-Latn-rs", "SR-Latn-RS"],
+
+    // Language-Variant:
+    "sl-rozaj": ["sl-rozaj", "SL-rozaj"],
+    "sl-rozaj-biske": ["sl-rozaj-biske", "SL-rozaj-biske"],
+
+    // Language-Region-Variant:
+    "de-CH-1901": ["de-ch-1901", "DE-CH-1901"],
+    "sl-IT-nedis": ["sl-it-nedis", "SL-IT-nedis"],
+
+    // Language-Script-Region-Variant:
+    "hy-Latn-IT-arevela": ["hy-Latn-it-arevela", "HY-Latn-IT-arevela"],
+
+    // Language-Region:
+    "de-DE": ["de-de", "DE-DE"],
+    "en-US": ["en-us", "EN-US"],
+    "es-419": ["es-419", "ES-419"],
+
+    // Private use subtags:
+    "de-CH-x-phonebk": ["de-ch-x-phonebk", "de-ch-x-phonebk"],
+    "az-Arab-x-AZE-derbend": ["az-Arab-x-AZE-derbend", "AZ-Arab-x-AZE-derbend"],
+
+    // Private use registry values:
+    "x-whatever": ["x-whatever", "x-whatever"],
+    "qaa-Qaaa-QM-x-southern": ["qaa-Qaaa-qm-x-southern", "QAA-Qaaa-QM-x-southern"],
+    "de-Qaaa": ["de-Qaaa", "DE-Qaaa"],
+    "sr-Qaaa-RS": ["sr-Qaaa-rs", "SR-Qaaa-RS"],
+
+    // Tags that use extensions (examples ONLY -- extensions MUST be defined by revision or update to this document, or by RFC):
+    "en-US-u-islamcal": ["en-us-u-islamcal", "EN-US-u-islamcal"],
+    "zh-CN-a-myext-x-private": ["zh-cn-a-myext-x-private", "ZH-CN-a-myext-x-private"],
+    "en-a-myext-b-another": ["en-a-myext-b-another", "EN-a-myext-b-another"],
+
+    // Some Invalid Tags
+    "de-419-DE": ["de-419-de", "DE-419-DE"], // incorrect result
+    "a-DE": "a-DE",
+    "a-de": "a-de",
+    "ar-a-aaa-b-bbb-a-ccc": ["ar-a-aaa-b-bbb-a-ccc", "AR-a-aaa-b-bbb-a-ccc"], // incorrect result
+
+    "-": "-",
+    "-AB": "-AB",
+    "-ab": "-ab",
+    "-XYZ": "-XYZ",
+    "-xyz": "-xyz",
+
+    "": ["", null, 123, 0, {}, [], NaN, fluid.identity],
+
+    // Actual language packs for Windows
+    "az-Latn-AZ": [ "az-Latn-az", "AZ-Latn-AZ" ],
+    "bs-Latn-BA": [ "bs-Latn-ba", "BS-Latn-BA" ],
+    "ku-ARAB-IQ": [ "ku-ARAB-iq", "KU-ARAB-IQ" ],
+    "chr-CHER-US": [ "chr-CHER-us", "CHR-CHER-US" ],
+    "prs-AF": [ "prs-af", "PRS-AF" ],
+    "fil-PH": [ "fil-ph", "FIL-PH" ],
+    "ha-Latn-NG": [ "ha-Latn-ng", "HA-Latn-NG" ],
+    "iu-Latn-CA": [ "iu-Latn-ca", "IU-Latn-CA" ],
+    "quc-Latn-GT": [ "quc-Latn-gt", "QUC-Latn-GT" ],
+    "qut-GT": [ "qut-gt", "QUT-GT" ],
+    "kok-IN": [ "kok-in", "KOK-IN" ],
+    "pa-Arab-PK": [ "pa-Arab-pk", "PA-Arab-PK" ],
+    "quz-PE": [ "quz-pe", "QUZ-PE" ],
+    "sr-Cyrl-BA": [ "sr-Cyrl-ba", "SR-Cyrl-BA" ],
+    "sr-Cyrl-CS": [ "sr-Cyrl-cs", "SR-Cyrl-CS" ],
+    "sr-Cyrl-RS": [ "sr-Cyrl-rs", "SR-Cyrl-RS" ],
+    "nso-ZA": [ "nso-za", "NSO-ZA" ],
+    "sd-Arab-PK": [ "sd-Arab-pk", "SD-Arab-PK" ],
+    "tg-Cyrl-TJ": [ "tg-Cyrl-tj", "TG-Cyrl-TJ" ],
+    "uz-Latn-UZ": [ "uz-Latn-uz", "UZ-Latn-UZ" ],
+    "ca-ES-valencia": [ "ca-ES-valencia", "CA-ES-valencia" ]
+});
+
+// Tests for getLanguageNames();
 gpii.tests.windows.language.nameTests = fluid.freezeRecursive([
     {
         input: "en",
@@ -151,6 +237,21 @@ jqUnit.test("Checking current language", function () {
         jqUnit.assertEquals("The current language must be English (US) [en-US]. " +
             "Set GPII_IGNORE_LANGTEST to ignore the language failures.", englishUS, lcid);
     }
+});
+
+jqUnit.test("Test language code casing", function () {
+    var tests = gpii.tests.windows.language.codeCaseTests;
+    fluid.each(tests, function (inputs, langCode) {
+        inputs = fluid.makeArray(inputs);
+        inputs.push(langCode);
+
+        fluid.each(inputs, function (input) {
+            console.log(langCode, input);
+            var result = gpii.windows.language.fixCodeCase(input);
+            jqUnit.assertEquals("Language case should be correct", langCode, result);
+        });
+    });
+
 });
 
 jqUnit.test("Test getting current display language", function () {


### PR DESCRIPTION
Corrects the casing of language codes, so `en-gb` becomes `en-GB`.