### PR TITLE
GPII-2618: Not saving the current theme if it's a high-contrast one.

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -568,7 +568,7 @@ gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) 
         if (currentThemeFile !== defaultTheme) {
             gpii.windows.spiSettingsHandler.saveTheme(defaultTheme);
         }
-    } else {
+    } else if (!themeData.VisualStyles.HighContrast) {
         // Wallpaper
         var desktop = themeData["Control Panel\\Desktop"];
         if (!desktop) {


### PR DESCRIPTION
When setting a high-contrast theme while high-contrast is already on, the current theme was being saved.

This fix makes only the current theme be saved it it's not high-contrast, so the custom wallpaper is restored correctly.

https://github.com/GPII/universal/pull/724 can be ignored.