### PR TITLE
GPII-3739: Open USB folder.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -32,7 +32,9 @@ ffiBindings.Callback = function (cif, size, argc, errorReportCallback, fn) {
 
 var ffi = require("ffi-napi"),
     child_process = require("child_process"),
-    fluid = require("gpii-universal");
+    fluid = require("gpii-universal"),
+    fs = require("fs"),
+    path = require("path");
 
 var gpii = fluid.registerNamespace("gpii");
 var windows = fluid.registerNamespace("gpii.windows");
@@ -153,6 +155,31 @@ windows.kernel32 = ffi.Library("kernel32", {
     // https://docs.microsoft.com/windows/desktop/api/winnls/nf-winnls-lcidtolocalename
     "LCIDToLocaleName": [
         "int", [ t.WORD, "char*", "int", t.DWORD ]
+    ],
+    // https://docs.microsoft.com/windows/desktop/api/fileapi/nf-fileapi-getlogicaldrivestringsw
+    "GetLogicalDriveStringsW": [
+        t.DWORD, [ t.DWORD, "char*" ]
+    ],
+    // https://docs.microsoft.com/windows/desktop/api/fileapi/nf-fileapi-getdrivetypew
+    "GetDriveTypeW": [
+        t.UINT, [ "char*" ]
+    ],
+    // https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol
+    "DeviceIoControl": [
+        t.BOOL, [
+            t.HANDLE,  // hDevice,
+            t.DWORD,   // dwIoControlCode,
+            t.PVOID,   // lpInBuffer,
+            t.DWORD,   // nInBufferSize,
+            t.PVOID,   // lpOutBuffer,
+            t.DWORD,   // nOutBufferSize,
+            t.LPDWORD, // lpBytesReturned,
+            "int"      // lpOverlapped
+        ]
+    ],
+    // https://msdn.microsoft.com/library/aa363858
+    "CreateFileW": [
+        t.HANDLE, [ "char*", t.DWORD, t.DWORD, t.HANDLE, t.DWORD, t.DWORD, t.HANDLE ]
     ]
 });
 
@@ -597,7 +624,9 @@ windows.API_constants = {
     SM_CXDOUBLECLK: 36,
     SM_CYDOUBLECLK: 37,
 
-    SM_SWAPBUTTON: 23
+    SM_SWAPBUTTON: 23,
+
+    INVALID_HANDLE_VALUE: 0xffffffff
 };
 
 fluid.each(windows.API_constants.returnCodesLookup, function (value, key) {
@@ -1737,6 +1766,143 @@ gpii.windows.nativeExec = function (command, options, callback) {
         execOptions.shell = process.env.SYSTEMROOT + "\\Sysnative\\cmd.exe";
     }
     return child_process.exec(command, execOptions, callback);
+};
+
+/**
+ * Gets a list of all drives on the system.
+ * @return {Array<String>} Array of paths to each drive on the system (eg, "c:\")
+ */
+gpii.windows.getAllDrives = function () {
+    var drivesBuffer = Buffer.alloc(0xff);
+    windows.kernel32.GetLogicalDriveStringsW(drivesBuffer.length, drivesBuffer);
+
+    var drives = windows.stringFromWideCharArray(drivesBuffer);
+
+    return drives;
+};
+
+/**
+ * Gets the USB drives that are available.
+ *
+ * @param {Array<String>} drivePaths [optional] Array of drives to check. Omit to check all drives on the system.
+ * @return {Array<String>} Array of paths to each USB drive.
+ */
+gpii.windows.getUsbDrives = function (drivePaths) {
+
+    var DRIVE_REMOVABLE = 2, DRIVE_FIXED = 3;
+    var FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2;
+    var OPEN_EXISTING = 3;
+    var IOCTL_STORAGE_QUERY_PROPERTY = 0x2d1400;
+    var BusTypeUsb = 7; // STORAGE_BUS_TYPE.BusTypeUsb
+
+    // Get all the drives.
+    var drives = drivePaths || gpii.windows.getAllDrives();
+
+    drives = drives.filter(function (drivePath) {
+        var busType = 0;
+        var driveHandle = null;
+
+        // GetDriveType is used to get a basic list of drives. This doesn't discriminate internal drives from usb
+        // drives, but it does eliminate things like CD-ROM and network drives.
+        var type = gpii.windows.kernel32.GetDriveTypeW(gpii.windows.stringToWideChar(drivePath));
+        if (type === DRIVE_FIXED || type === DRIVE_REMOVABLE) {
+            // Get a handle to the volume. Volume path is in the form of "\\.\A:"
+            var volumePath = "\\\\.\\" + drivePath.substr(0, 2);
+            driveHandle = gpii.windows.kernel32.CreateFileW(
+                gpii.windows.stringToWideChar(volumePath), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+
+            if (driveHandle === windows.API_constants.INVALID_HANDLE_VALUE) {
+                fluid.log("Unable to open the volume " + drivePath + ": "
+                    + gpii.windows.win32errorText("CreateFileW", driveHandle));
+                driveHandle = null;
+            }
+        }
+
+        if (driveHandle !== null) {
+            // PropertyStandardQuery and StorageDeviceProperty is used for the query - both zeroes so just pass a buffer of
+            // zeroes.
+            var querySize = 12; // sizeof(STORAGE_PROPERTY_QUERY)
+            var query = Buffer.alloc(querySize);
+            query.fill(0);
+
+            // Stores the resulting device descriptor
+            var devDescSize = 40; // sizeof(STORAGE_DEVICE_DESCRIPTOR)
+            var devDesc = Buffer.alloc(devDescSize);
+            devDesc.fill(0);
+            // Unused, but required.
+            var byteCountBuffer = ref.alloc(gpii.windows.types.DWORD);
+
+            // Get the device descriptor for the volume.
+            var success = gpii.windows.kernel32.DeviceIoControl(
+                driveHandle,
+                IOCTL_STORAGE_QUERY_PROPERTY,
+                query, querySize,
+                devDesc, devDescSize,
+                byteCountBuffer.ref(), 0);
+
+            if (success) {
+                // Get the busType from the device descriptor.
+                var busTypeOffset = 28;
+                busType = devDesc.readInt32LE(busTypeOffset);
+            } else {
+                fluid.log("Unable to determine the bus type for drive " + drivePath + ": "
+                    + gpii.windows.win32errorText("DeviceIoControl", success));
+            }
+        }
+
+        return busType === BusTypeUsb;
+    });
+
+    return drives;
+};
+
+/**
+ * Used by the "Open USB" button. Gets the user's USB drives. That is, those without a token file.
+ * If all drives have a token file, then all are returned.
+ *
+ * @param {Array<String>} usbDrives [optional] The root paths to the usb drives to check, omit to check all USB drives
+ * on the system.
+ * @return {Array<String>} Array of paths to each drive.
+ */
+gpii.windows.getUserUsbDrives = function (usbDrives) {
+    usbDrives = usbDrives || gpii.windows.getUsbDrives();
+    var tokenFile = ".gpii-user-token.txt";
+    var promiseTogo = fluid.promise();
+
+    if (usbDrives.length < 1) {
+        // Always return the single drive.
+        promiseTogo.resolve(usbDrives);
+    } else {
+        var promises = [];
+        var result = [];
+
+        // Check each drive for the token file.
+        fluid.each(usbDrives, function (drivePath) {
+            var tokenPath = path.join(drivePath, tokenFile);
+            var promise = fluid.promise();
+            promises.push(promise);
+
+            fs.access(tokenPath, function (err) {
+                if (err) {
+                    // No token file found, so add it to the result.
+                    result.push(drivePath);
+                }
+                promise.resolve(!err);
+            });
+        });
+
+        fluid.promise.sequence(promises).then(function () {
+            if (result.length === 0) {
+                // No drives where added (they all had a token file), then return all of them.
+                promiseTogo.resolve(usbDrives);
+            } else {
+                promiseTogo.resolve(result);
+            }
+        });
+    }
+
+    return promiseTogo;
+
 };
 
 exports.windows = windows;

--- a/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
+++ b/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
@@ -13,11 +13,27 @@
 "use strict";
 
 var fluid = require("gpii-universal"),
-    jqUnit = fluid.require("node-jqunit");
+    jqUnit = fluid.require("node-jqunit"),
+    os = require("os"),
+    fs = require("fs"),
+    path = require("path"),
+    rimraf = require("rimraf");
 
 require("../WindowsUtilities.js");
 
+
+var gpii = fluid.registerNamespace("gpii");
 var windows = fluid.registerNamespace("gpii.windows");
+fluid.registerNamespace("gpii.tests.windows");
+
+var teardowns = [];
+jqUnit.module("gpii.tests.windows.windowsUtilities", {
+    teardown: function () {
+        while (teardowns.length) {
+            teardowns.pop()();
+        }
+    }
+});
 
 jqUnit.test("Testing 'windows.resolveFlags' function with SpiFlags", function () {
     jqUnit.expect(1);
@@ -80,4 +96,307 @@ jqUnit.test("Testing 'windows.translateLastError' function", function () {
         var msgRes = windows.translateLastError(msgMap[0]);
         jqUnit.assertDeepEq("Checking expected message with error translation", msgMap[1], msgRes);
     });
+});
+
+jqUnit.test("Testing getAllDrives", function () {
+    var drives = gpii.windows.getAllDrives();
+
+    jqUnit.assertTrue("getAllDrives should return an array", Array.isArray(drives));
+    jqUnit.assertTrue("There should be at least one drive", drives.length > 0);
+
+    fluid.log("drives:", drives);
+
+    var gotSystem = false;
+    var systemPath = process.env.SystemRoot.substr(0, 3).toUpperCase();
+
+    fluid.each(drives, function (path) {
+        if (!gotSystem) {
+            gotSystem = path === systemPath;
+        }
+        jqUnit.assertTrue("All paths should look like a drive root", path.match(/^[A-Z]:\\/));
+    });
+
+    // Check some sanity of the list.
+    jqUnit.assertTrue("SystemRoot drive should have been found (" + systemPath + ")", gotSystem);
+});
+
+gpii.tests.windows.driveTypes = {
+    DRIVE_REMOVABLE: 2, DRIVE_FIXED: 3, DRIVE_REMOTE: 4, DRIVE_CDROM: 5
+};
+
+gpii.tests.windows.getUsbDrivesTests = fluid.freezeRecursive({
+    "C:\\": {
+        // Fixed drive, not usb
+        volumePath: "\\\\.\\C:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_FIXED,
+        CreateFileW: 1,
+        DeviceIoControl: 1,
+        usb: false,
+        expected: false
+    },
+    "D:\\": {
+        // cd-rom drive
+        volumePath: "\\\\.\\D:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_CDROM,
+        CreateFileW: "unexpected",
+        DeviceIoControl: "unexpected",
+        usb: false,
+        expected: false
+    },
+    "E:\\": {
+        // cd-rom drive, usb
+        volumePath: "\\\\.\\E:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_CDROM,
+        CreateFileW: "unexpected",
+        DeviceIoControl: "unexpected",
+        usb: false,
+        expected: false
+    },
+    "F:\\": {
+        // network drive
+        volumePath: "\\\\.\\F:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_REMOTE,
+        CreateFileW: "unexpected",
+        DeviceIoControl: "unexpected",
+        usb: false,
+        expected: false
+    },
+    "G:\\": {
+        // fixed drive, usb
+        volumePath: "\\\\.\\G:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_FIXED,
+        CreateFileW: 1,
+        DeviceIoControl: 1,
+        usb: true,
+        expected: true
+    },
+    "H:\\": {
+        // removable drive, non-usb
+        volumePath: "\\\\.\\H:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_REMOVABLE,
+        CreateFileW: 1,
+        DeviceIoControl: 1,
+        usb: false,
+        expected: false
+    },
+    "I:\\": {
+        // removable drive, usb
+        volumePath: "\\\\.\\I:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_REMOVABLE,
+        CreateFileW: 1,
+        DeviceIoControl: 1,
+        usb: true,
+        expected: true
+    },
+    "J:\\": {
+        // another fixed drive, usb
+        volumePath: "\\\\.\\J:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_FIXED,
+        CreateFileW: 1,
+        DeviceIoControl: 1,
+        usb: true,
+        expected: true
+    },
+    // Errors
+    "O:\\": {
+        // CreateFile failed
+        volumePath: "\\\\.\\O:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_FIXED,
+        CreateFileW: gpii.windows.API_constants.INVALID_HANDLE_VALUE,
+        DeviceIoControl: "unexpected",
+        expected: false
+    },
+    "P:\\": {
+        // DeviceIoControl failed
+        volumePath: "\\\\.\\P:",
+        GetDriveTypeW: gpii.tests.windows.driveTypes.DRIVE_FIXED,
+        CreateFileW: 1,
+        DeviceIoControl: 0,
+        expected: false
+    }
+});
+
+jqUnit.test("Testing getUsbDrives", function () {
+
+    // Call it normally - the result is unpredictable, but it shouldn't crash. There should be at least one fixed drive,
+    // so that will flow mostly through the happy path, calling all real API functions.
+    var drives = gpii.windows.getUsbDrives();
+    fluid.log("gpii.windows.getUsbDrives:", drives);
+
+    jqUnit.assertTrue("getUsbDrives returns an array", Array.isArray(drives));
+
+    // Mock the API calls to return the expected values.
+    var origValues = {
+        GetDriveTypeW: gpii.windows.kernel32.GetDriveTypeW,
+        CreateFileW: gpii.windows.kernel32.CreateFileW,
+        DeviceIoControl: gpii.windows.kernel32.DeviceIoControl
+    };
+
+    var tests = gpii.tests.windows.getUsbDrivesTests;
+    var currentTest;
+
+    gpii.windows.kernel32.GetDriveTypeW = function (lpRootPathName) {
+        var drivePath = gpii.windows.stringFromWideChar(lpRootPathName);
+        fluid.log("Testing drive " + drivePath);
+        currentTest = tests[drivePath];
+        jqUnit.assertNotNull("GetDriveTypeW called with a test drive", currentTest);
+
+        return currentTest.GetDriveTypeW;
+    };
+
+    gpii.windows.kernel32.CreateFileW = function (lpFileName) {
+
+        jqUnit.assertNotEquals("CreateFileW should only be called if expected", "unexpected", currentTest.CreateFileW);
+
+        jqUnit.assertEquals("CreateFileW called with lpFileName as the volume path",
+            currentTest.volumePath, gpii.windows.stringFromWideChar(lpFileName));
+        return currentTest.CreateFileW;
+    };
+
+    gpii.windows.kernel32.DeviceIoControl = function (
+        hDevice, dwIoControlCode, lpInBuffer, nInBufferSize, lpOutBuffer, nOutBufferSize) {
+
+        jqUnit.assertNotEquals("DeviceIoControl should only be called if expected",
+            "unexpected", currentTest.DeviceIoControl);
+
+        jqUnit.assertEquals("DeviceIoControl called with hDevice as the CreateFile result",
+            currentTest.CreateFileW, hDevice);
+
+        jqUnit.assertTrue("DeviceIoControl called with a buffer for lpInBuffer", lpInBuffer instanceof Buffer);
+        jqUnit.assertTrue("DeviceIoControl called with a buffer for lpOutBuffer", lpOutBuffer instanceof Buffer);
+        jqUnit.assertEquals("DeviceIoControl called with matching nInBufferSize and lpInBuffer.length",
+            lpInBuffer.length, nInBufferSize);
+        jqUnit.assertEquals("DeviceIoControl called with matching nOutBufferSize and lpOutBuffer.length",
+            lpOutBuffer.length, nOutBufferSize);
+
+        var BusTypeUsb = 7;
+        var busType = currentTest.usb ? BusTypeUsb : 1;
+        lpOutBuffer.writeInt32LE(busType, 28);
+
+        return currentTest.DeviceIoControl;
+    };
+
+    try {
+
+        var result = gpii.windows.getUsbDrives(Object.keys(tests));
+
+        var expected = [];
+        fluid.each(tests, function (test, key) {
+            if (test.expected) {
+                expected.push(key);
+            }
+        });
+
+        jqUnit.assertDeepEq("getUsbDrives should return the expected drive paths", expected, result);
+
+    } finally {
+        fluid.each(Object.keys(origValues), function (funcName) {
+            gpii.windows.kernel32[funcName] = origValues[funcName];
+        });
+    }
+
+});
+
+gpii.tests.windows.getUserUsbDrivesTests = fluid.freezeRecursive({
+    "single drive, with token": {
+        drives: [true],
+        expect: ["A"]
+    },
+    "single drive, no token": {
+        drives: [false],
+        expect: ["A"]
+    },
+    "two drives, no tokens": {
+        drives: [false, false],
+        expect: ["A", "B"]
+    },
+    "two drives, 1st with token": {
+        drives: [true, false],
+        expect: ["B"]
+    },
+    "two drives, 2nd with token": {
+        drives: [false, true],
+        expect: ["A"]
+    },
+    "two drives, both with token": {
+        drives: [true, true],
+        expect: ["A", "B"]
+    },
+    "three drives, no token": {
+        drives: [false, false, false],
+        expect: ["A", "B", "C"]
+    },
+    "three drives, 1 token": {
+        drives: [false, true, false],
+        expect: ["A", "C"]
+    },
+    "three drives, 2 tokens": {
+        drives: [true, true, false],
+        expect: ["C"]
+    },
+    "three drives, 3 tokens": {
+        drives: [true, true, true],
+        expect: ["A", "B", "C"]
+    },
+    "no drives": {
+        drives: [],
+        expect: []
+    }
+});
+
+jqUnit.asyncTest("Testing getUserUsbDrives", function () {
+
+    var tests = fluid.hashToArray(gpii.tests.windows.getUserUsbDrivesTests, "name");
+
+    var testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gpii-usb-test"));
+    teardowns.push(function () {
+        rimraf.sync(testRoot);
+    });
+
+    var tokenFile = ".gpii-user-token.txt";
+
+    jqUnit.expect(tests.length * 2);
+
+    // Create a few directories (some containing a token file) and pass them to getUserUsbDrives as though they're
+    // drive roots.
+    var doTest = function (testIndex) {
+        var currentTest = tests[testIndex];
+        if (!currentTest) {
+            jqUnit.start();
+            return;
+        }
+        var letters = "ABCDE";
+        var testDir = fs.mkdtempSync(path.join(testRoot, "test"));
+        var testDrives = [];
+
+        // Create some directories to act as drives.
+        fluid.each(currentTest.drives, function (hasToken, index) {
+            var testDrive = path.join(testDir, letters[index]);
+            testDrives.push(testDrive);
+            fs.mkdirSync(testDrive);
+            if (hasToken) {
+                // Add the token, if required.
+                fs.writeFileSync(path.join(testDrive, tokenFile));
+            }
+        });
+
+        var promise = gpii.windows.getUserUsbDrives(testDrives);
+
+        jqUnit.assertTrue("getUserUsbDrives should return a promise", fluid.isPromise(promise));
+
+        promise.then(function (drives) {
+            var driveLetters = fluid.transform(drives, function (path) {
+                return path.substr(path.length - 1, 1);
+            });
+
+            fluid.log(currentTest.name, driveLetters);
+
+            jqUnit.assertDeepEq("getUserUsbDrives should resolve with the expected value - " + currentTest.name,
+                currentTest.expect, driveLetters);
+
+            doTest(testIndex + 1);
+        });
+    };
+
+    doTest(0);
 });

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -518,7 +518,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
-    if (currentThemeFile && saveAs && currentThemeFile !== saveAs) {
+    if (currentThemeFile && saveAs) {
         gpii.windows.spiSettingsHandler.saveTheme(currentThemeFile, saveAs);
     }
 

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -514,7 +514,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
-    if (currentThemeFile && saveAs) {
+    if (currentThemeFile && saveAs && currentThemeFile !== saveAs) {
         gpii.windows.spiSettingsHandler.saveTheme(currentThemeFile, saveAs);
     }
 


### PR DESCRIPTION
Back-end for the open usb button, which performs the following:

- If a single USB Drive is found, then that gets opened.
- If there's more than 1, then all drives that don't have a gpii token file are opened. (if all drives have a token then all are opened)

A "USB Drive" is a fixed or removal volume on the USB bus (which isn't a CD-ROM or Ramdisk).

Used by https://github.com/GPII/gpii-app/pull/92