### PR TITLE
GPII-3807: getUserUsbDrives test failure.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
+++ b/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
@@ -392,7 +392,7 @@ jqUnit.asyncTest("Testing getUserUsbDrives", function () {
             fluid.log(currentTest.name, driveLetters);
 
             jqUnit.assertDeepEq("getUserUsbDrives should resolve with the expected value - " + currentTest.name,
-                currentTest.expect, driveLetters);
+                currentTest.expect, driveLetters.sort());
 
             doTest(testIndex + 1);
         });


### PR DESCRIPTION
Sorting the result array before assertion.

The array is built asynchronously, so the order isn't guaranteed (nor does it matter).