### PR TITLE
GPII-3811: Make custom high-contrast themes work with updated Windows.

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -514,7 +514,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @param {String} newThemeFile The .theme file, which is in INI file format.
  * @param {String} currentThemeFile The current .theme file, which is in INI file format.
  * @param {String} saveAs The .theme file to which the current theme is saved.
- * @param {Boolean} dryRun true to not update the registry.
+ * @param {Boolean}  dryRun true to not update the registry.
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
@@ -544,6 +544,10 @@ gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, c
         if (displayName && !dryRun) {
             gpii.windows.writeRegistryKey("HKEY_CURRENT_USER", "Control Panel\\Accessibility\\HighContrast",
                 "High Contrast Scheme", displayName, "REG_SZ");
+            // Store the current theme file so it can be referred to later.
+            gpii.windows.writeRegistryKey(
+                "HKEY_CURRENT_USER", "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast",
+                "LastSet", newThemeFile, "REG_SZ");
         }
     }
 
@@ -619,12 +623,89 @@ gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) 
     }
 };
 
+/**
+ * Manually apply the colours of a given .theme file.
+ * After upgrading to version 1810 of Windows 10, the custom themes provided by Morphic stopped working [GPII-3811].
+ * Due to lack of time/knowledge, the cause is currently unknown. To work-around this, the .theme file is read and the
+ * colours are manually applied. This is called after the high-contrast theme has been applied.
+ *
+ * @param {String} themeFile The .theme file.
+ * @param {Boolean} allThemes true to apply every theme, rather than just the custom ones.
+ */
+gpii.windows.spiSettingsHandler.applyCustomTheme = function (themeFile, allThemes) {
+    var themeData = gpii.iniFile.readFile(themeFile);
+    fluid.log("applyCustomTHeme", arguments);
+
+    var isValid = themeData && themeData.Theme;
+    // The custom themes, unlike the built-in ones, have the ThemeId value set.
+    if (isValid && (themeData.Theme.ThemeId || allThemes)) {
+        // The list of colour names, whose index is the value of the corresponding API constant.
+        var colorNames = [
+            "Scrollbar",
+            "Background",
+            "ActiveTitle",
+            "InactiveTitle",
+            "Menu",
+            "Window",
+            "WindowFrame",
+            "MenuText",
+            "WindowText",
+            "TitleText",
+            "ActiveBorder",
+            "InactiveBorder",
+            "AppWorkspace",
+            "Hilight",
+            "HilightText",
+            "ButtonFace",
+            "ButtonShadow",
+            "GrayText",
+            "ButtonText",
+            "InactiveTitleText",
+            "ButtonHilight",
+            "ButtonDkShadow",
+            "ButtonLight",
+            "InfoText",
+            "InfoWindow",
+            "ButtonAlternateFace",
+            "HotTrackingColor",
+            "GradientActiveTitle",
+            "GradientInactiveTitle",
+            "MenuHilight",
+            "MenuBar"
+        ];
+
+        var colors = themeData["Control Panel\\Colors"];
+        var colorNumbers = [];
+        var colorValues = [];
+        fluid.each(colors, function (rgbValues, name) {
+            colorNumbers.push(colorNames.indexOf(name));
+            var rgb = rgbValues.split(" ");
+            colorValues.push(rgb[0] | rgb[1] << 8 | rgb[2] << 16);
+        });
+
+
+        /*eslint-env es6, Int32Array is undefined */
+        var elementsBuffer = Int32Array.from(colorNumbers);
+        var valuesBuffer = Int32Array.from(colorValues);
+        gpii.windows.user32.SetSysColors(elementsBuffer.length, elementsBuffer, valuesBuffer);
+    }
+
+};
+
 fluid.defaults("gpii.windows.spiSettingsHandler.setHighContrastTheme", {
     gradeNames: "fluid.function",
     argumentMap: {
         newTheme: 0,
         currentTheme: 1,
         saveAs: 2
+    }
+});
+
+fluid.defaults("gpii.windows.spiSettingsHandler.applyCustomTheme", {
+    gradeNames: "fluid.function",
+    argumentMap: {
+        themeFile: 0,
+        allThemes: 1
     }
 });
 

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -624,6 +624,44 @@ gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) 
 };
 
 /**
+ * The list of colour names for the .theme file, whose index is the value of the corresponding API constant, which are
+ * listed in https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-getsyscolor
+ */
+gpii.windows.spiSettingsHandler.themeColours = fluid.freezeRecursive([
+    "Scrollbar",
+    "Background",
+    "ActiveTitle",
+    "InactiveTitle",
+    "Menu",
+    "Window",
+    "WindowFrame",
+    "MenuText",
+    "WindowText",
+    "TitleText",
+    "ActiveBorder",
+    "InactiveBorder",
+    "AppWorkspace",
+    "Hilight",
+    "HilightText",
+    "ButtonFace",
+    "ButtonShadow",
+    "GrayText",
+    "ButtonText",
+    "InactiveTitleText",
+    "ButtonHilight",
+    "ButtonDkShadow",
+    "ButtonLight",
+    "InfoText",
+    "InfoWindow",
+    "ButtonAlternateFace",
+    "HotTrackingColor",
+    "GradientActiveTitle",
+    "GradientInactiveTitle",
+    "MenuHilight",
+    "MenuBar"
+]);
+
+/**
  * Manually apply the colours of a given .theme file.
  * After upgrading to version 1810 of Windows 10, the custom themes provided by Morphic stopped working [GPII-3811].
  * Due to lack of time/knowledge, the cause is currently unknown. To work-around this, the .theme file is read and the
@@ -639,51 +677,14 @@ gpii.windows.spiSettingsHandler.applyCustomTheme = function (themeFile, allTheme
     var isValid = themeData && themeData.Theme;
     // The custom themes, unlike the built-in ones, have the ThemeId value set.
     if (isValid && (themeData.Theme.ThemeId || allThemes)) {
-        // The list of colour names, whose index is the value of the corresponding API constant, which are listed in
-        // https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-getsyscolor
-        var colorNames = [
-            "Scrollbar",
-            "Background",
-            "ActiveTitle",
-            "InactiveTitle",
-            "Menu",
-            "Window",
-            "WindowFrame",
-            "MenuText",
-            "WindowText",
-            "TitleText",
-            "ActiveBorder",
-            "InactiveBorder",
-            "AppWorkspace",
-            "Hilight",
-            "HilightText",
-            "ButtonFace",
-            "ButtonShadow",
-            "GrayText",
-            "ButtonText",
-            "InactiveTitleText",
-            "ButtonHilight",
-            "ButtonDkShadow",
-            "ButtonLight",
-            "InfoText",
-            "InfoWindow",
-            "ButtonAlternateFace",
-            "HotTrackingColor",
-            "GradientActiveTitle",
-            "GradientInactiveTitle",
-            "MenuHilight",
-            "MenuBar"
-        ];
-
         var colors = themeData["Control Panel\\Colors"];
         var colorNumbers = [];
         var colorValues = [];
         fluid.each(colors, function (rgbValues, name) {
-            colorNumbers.push(colorNames.indexOf(name));
+            colorNumbers.push(gpii.windows.spiSettingsHandler.themeColours.indexOf(name));
             var rgb = rgbValues.split(" ");
             colorValues.push(rgb[0] | rgb[1] << 8 | rgb[2] << 16);
         });
-
 
         /* global Int32Array */
         var elementsBuffer = Int32Array.from(colorNumbers);

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -514,7 +514,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @param {String} newThemeFile The .theme file, which is in INI file format.
  * @param {String} currentThemeFile The current .theme file, which is in INI file format.
  * @param {String} saveAs The .theme file to which the current theme is saved.
- * @param {Boolean}  dryRun true to not update the registry.
+ * @param {Boolean} dryRun true to not update the registry.
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
@@ -639,7 +639,8 @@ gpii.windows.spiSettingsHandler.applyCustomTheme = function (themeFile, allTheme
     var isValid = themeData && themeData.Theme;
     // The custom themes, unlike the built-in ones, have the ThemeId value set.
     if (isValid && (themeData.Theme.ThemeId || allThemes)) {
-        // The list of colour names, whose index is the value of the corresponding API constant.
+        // The list of colour names, whose index is the value of the corresponding API constant, which are listed in
+        // https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-getsyscolor
         var colorNames = [
             "Scrollbar",
             "Background",
@@ -684,7 +685,7 @@ gpii.windows.spiSettingsHandler.applyCustomTheme = function (themeFile, allTheme
         });
 
 
-        /*eslint-env es6, Int32Array is undefined */
+        /* global Int32Array */
         var elementsBuffer = Int32Array.from(colorNumbers);
         var valuesBuffer = Int32Array.from(colorValues);
         gpii.windows.user32.SetSysColors(elementsBuffer.length, elementsBuffer, valuesBuffer);


### PR DESCRIPTION
Still unsure of the underlying cause, but here's a workaround.

After the theme has been applied, this fix just reads the .theme file and manually applies the colours.

Works well with https://github.com/GPII/universal/pull/761