### PR TITLE
NO-JIRA: Not listing USB removable drives (like SD cards).

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -1788,7 +1788,7 @@ gpii.windows.getAllDrives = function () {
  * @return {Array<String>} Array of paths to each USB drive.
  */
 gpii.windows.getUsbDrives = function (drivePaths) {
-    var DRIVE_REMOVABLE = 2, DRIVE_FIXED = 3;
+    var DRIVE_FIXED = 3;
     var FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2;
     var OPEN_EXISTING = 3;
     var IOCTL_STORAGE_QUERY_PROPERTY = 0x2d1400;
@@ -1804,7 +1804,7 @@ gpii.windows.getUsbDrives = function (drivePaths) {
         // GetDriveType is used to get a basic list of drives. This doesn't discriminate internal drives from usb
         // drives, but it does eliminate things like CD-ROM and network drives.
         var type = gpii.windows.kernel32.GetDriveTypeW(gpii.windows.stringToWideChar(drivePath));
-        if (type === DRIVE_FIXED || type === DRIVE_REMOVABLE) {
+        if (type === DRIVE_FIXED) {
             // Get a handle to the volume. Volume path is in the form of "\\.\A:"
             var volumePath = "\\\\.\\" + drivePath.substr(0, 2);
             driveHandle = gpii.windows.kernel32.CreateFileW(

--- a/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
+++ b/gpii/node_modules/WindowsUtilities/test/WindowsUtilitiesTests.js
@@ -186,7 +186,7 @@ gpii.tests.windows.getUsbDrivesTests = fluid.freezeRecursive({
         CreateFileW: 1,
         DeviceIoControl: 1,
         usb: true,
-        expected: true
+        expected: false
     },
     "J:\\": {
         // another fixed drive, usb


### PR DESCRIPTION
Fixes the problem where "phantom usb drives" where being shown with the open USB button.

These drives are probably empty SD cards.