### PR TITLE
GPII-3739: Closing the handle to the usb device after finishing with it.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -1802,51 +1802,58 @@ gpii.windows.getUsbDrives = function (drivePaths) {
         var busType = 0;
         var driveHandle = null;
 
-        // GetDriveType is used to get a basic list of drives. This doesn't discriminate internal drives from usb
-        // drives, but it does eliminate things like CD-ROM and network drives.
-        var type = gpii.windows.kernel32.GetDriveTypeW(gpii.windows.stringToWideChar(drivePath));
-        if (type === DRIVE_FIXED || type === DRIVE_REMOVABLE) {
-            // Get a handle to the volume. Volume path is in the form of "\\.\A:"
-            var volumePath = "\\\\.\\" + drivePath.substr(0, 2);
-            driveHandle = gpii.windows.kernel32.CreateFileW(
-                gpii.windows.stringToWideChar(volumePath), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+        try {
+            // GetDriveType is used to get a basic list of drives. This doesn't discriminate internal drives from usb
+            // drives, but it does eliminate things like CD-ROM and network drives.
+            var type = gpii.windows.kernel32.GetDriveTypeW(gpii.windows.stringToWideChar(drivePath));
+            if (type === DRIVE_FIXED || type === DRIVE_REMOVABLE) {
+                // Get a handle to the volume. Volume path is in the form of "\\.\A:"
+                var volumePath = "\\\\.\\" + drivePath.substr(0, 2);
+                driveHandle = gpii.windows.kernel32.CreateFileW(
+                    gpii.windows.stringToWideChar(volumePath), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
 
-            if (driveHandle === windows.API_constants.INVALID_HANDLE_VALUE) {
-                fluid.log("Unable to open the volume " + drivePath + ": "
-                    + gpii.windows.win32errorText("CreateFileW", driveHandle));
-                driveHandle = null;
+                if (driveHandle === windows.API_constants.INVALID_HANDLE_VALUE) {
+                    fluid.log("Unable to open the volume " + drivePath + ": "
+                        + gpii.windows.win32errorText("CreateFileW", driveHandle));
+                    driveHandle = null;
+                }
             }
-        }
 
-        if (driveHandle !== null) {
-            // PropertyStandardQuery and StorageDeviceProperty is used for the query - both zeroes so just pass a buffer of
-            // zeroes.
-            var querySize = 12; // sizeof(STORAGE_PROPERTY_QUERY)
-            var query = Buffer.alloc(querySize);
-            query.fill(0);
+            if (driveHandle !== null) {
+                // PropertyStandardQuery and StorageDeviceProperty is used for the query - both zeroes so just pass a buffer of
+                // zeroes.
+                var querySize = 12; // sizeof(STORAGE_PROPERTY_QUERY)
+                var query = Buffer.alloc(querySize);
+                query.fill(0);
 
-            // Stores the resulting device descriptor
-            var devDescSize = 40; // sizeof(STORAGE_DEVICE_DESCRIPTOR)
-            var devDesc = Buffer.alloc(devDescSize);
-            devDesc.fill(0);
-            // Unused, but required.
-            var byteCountBuffer = ref.alloc(gpii.windows.types.DWORD);
+                // Stores the resulting device descriptor
+                var devDescSize = 40; // sizeof(STORAGE_DEVICE_DESCRIPTOR)
+                var devDesc = Buffer.alloc(devDescSize);
+                devDesc.fill(0);
+                // Unused, but required.
+                var byteCountBuffer = ref.alloc(gpii.windows.types.DWORD);
 
-            // Get the device descriptor for the volume.
-            var success = gpii.windows.kernel32.DeviceIoControl(
-                driveHandle,
-                IOCTL_STORAGE_QUERY_PROPERTY,
-                query, querySize,
-                devDesc, devDescSize,
-                byteCountBuffer.ref(), 0);
+                // Get the device descriptor for the volume.
+                var success = gpii.windows.kernel32.DeviceIoControl(
+                    driveHandle,
+                    IOCTL_STORAGE_QUERY_PROPERTY,
+                    query, querySize,
+                    devDesc, devDescSize,
+                    byteCountBuffer.ref(), 0);
 
-            if (success) {
-                // Get the busType from the device descriptor.
-                var busTypeOffset = 28;
-                busType = devDesc.readInt32LE(busTypeOffset);
-            } else {
-                fluid.log("Unable to determine the bus type for drive " + drivePath + ": "
-                    + gpii.windows.win32errorText("DeviceIoControl", success));
+                if (success) {
+                    // Get the busType from the device descriptor.
+                    var busTypeOffset = 28;
+                    busType = devDesc.readInt32LE(busTypeOffset);
+                } else {
+                    fluid.log("Unable to determine the bus type for drive " + drivePath + ": "
+                        + gpii.windows.win32errorText("DeviceIoControl", success));
+                }
+            }
+
+        } finally {
+            if (driveHandle !== null) {
+                gpii.windows.kernel32.CloseHandle(driveHandle);
             }
         }
 


### PR DESCRIPTION
This fixes the usb task tray icon not being able to eject the usb drive, after opening it with GPII.

(most of the change is re-indentation for a try-catch block)