### PR TITLE
GPII-3852: Stop showing languages that are removed.

### DIFF
--- a/gpii/node_modules/gpii-localisation/src/language.js
+++ b/gpii/node_modules/gpii-localisation/src/language.js
@@ -109,10 +109,11 @@ gpii.windows.language.fixCodeCase = function (langCode) {
 
     return parts.join("-");
 };
+
 /**
  * Gets the display languages that are installed on the system, and updates the model.
  *
- * These are listed in HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\MUI\UILanguages
+ * These are listed in HKEY_CURRENT_USER\Control Panel\International\User Profile
  *
  * @param {Component} that The gpii.windows.language instance.
  * @return {Promise<Map<String,InstalledLanguage>>} A promise, resolving with either the language names if the list has
@@ -120,7 +121,7 @@ gpii.windows.language.fixCodeCase = function (langCode) {
  */
 gpii.windows.language.getInstalled = function (that) {
     var langCodes = gpii.windows.enumRegistryKeys(
-        "HKEY_LOCAL_MACHINE", "SYSTEM\\CurrentControlSet\\Control\\MUI\\UILanguages");
+        "HKEY_CURRENT_USER\\", "Control Panel\\International\\User Profile");
 
     langCodes = langCodes.map(gpii.windows.language.fixCodeCase);
 

--- a/gpii/node_modules/gpii-localisation/src/language.js
+++ b/gpii/node_modules/gpii-localisation/src/language.js
@@ -88,6 +88,11 @@ fluid.defaults("gpii.windows.language", {
 gpii.windows.language.fixCodeCase = function (langCode) {
     var parts = (langCode && langCode.split) ? langCode.split("-") : [];
 
+    // Handle the case where just a language is presented, and also use that as the region. eg, "pl" becomes "pl-PL".
+    if (parts.length === 1 && parts[0].length === 2) {
+        parts.push(parts[0]);
+    }
+
     // [RFC-5646] Language is always the first section - "2*3ALPHA ; shortest ISO 639 code"
     if (parts.length > 0 && (parts[0].length === 2 || parts[0].length === 3)) {
         parts[0] = parts[0].toLowerCase();
@@ -121,7 +126,7 @@ gpii.windows.language.fixCodeCase = function (langCode) {
  */
 gpii.windows.language.getInstalled = function (that) {
     var langCodes = gpii.windows.enumRegistryKeys(
-        "HKEY_CURRENT_USER\\", "Control Panel\\International\\User Profile");
+        "HKEY_CURRENT_USER", "Control Panel\\International\\User Profile");
 
     langCodes = langCodes.map(gpii.windows.language.fixCodeCase);
 

--- a/gpii/node_modules/gpii-localisation/test/testLanguage.js
+++ b/gpii/node_modules/gpii-localisation/test/testLanguage.js
@@ -33,8 +33,8 @@ fluid.registerNamespace("gpii.tests.windows.language");
 // Language code casing tests (from https://tools.ietf.org/html/rfc5646#appendix-A)
 // expected => [inputs]
 gpii.tests.windows.language.codeCaseTests = fluid.freezeRecursive({
-    // Simple language subtag:
-    "de": ["de", "DE"],
+    // Simple language subtag, without region:
+    "bg-BG": ["bg", "bg"],
     // Language subtag plus Script subtag:
     "zh-Hant": ["zh-Hant", "ZH-Hant"],
     // Extended language subtags and their primary language subtag counterparts


### PR DESCRIPTION
This fix stops the QSS from showing languages after they have been removed.

To test:

1. Install a language, start morphic: the language should be on the pop-up.
2. Remove the language, restart morphic: the language should no longer be seen.