### PR TITLE
GPII-3866: Explorer wont restart in certain timing conditions

### DIFF
--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -453,14 +453,15 @@ gpii.windows.stopExplorer = function (options) {
                 // Explorer now expects to be killed
                 windows.killProcessByName(options.explorerExe);
             }
+
+            // The process has been known to linger, preventing a new instance. Give it until the timeout, then be more forceful
+            windows.waitForProcessTermination(options.explorerExe, {timeout: options.timeout}).then(promise.resolve, function () {
+                fluid.log("Explorer did not close - terminating");
+                windows.killProcessByName(options.explorerExe);
+                promise.resolve();
+            });
         });
 
-        // The process has been known to linger, preventing a new instance. Give it until the timeout, then be more forceful
-        windows.waitForProcessTermination(options.explorerExe, {timeout: options.timeout}).then(promise.resolve, function () {
-            fluid.log("Explorer did not close - terminating");
-            windows.killProcessByName(options.explorerExe);
-            promise.resolve();
-        });
     } else {
         // Explorer was not running.
         promise.resolve();


### PR DESCRIPTION
This patch was suggested by @stegru to improve the order of promise resolution that guarantees a proper explorer shutdown.