### PR TITLE
GPII-3927: Office simplification

### DIFF
--- a/gpii/node_modules/gpii-office/README.md
+++ b/gpii/node_modules/gpii-office/README.md
@@ -1,0 +1,5 @@
+# Office 
+
+This modules contains things to control and configure Microsoft Office.
+
+* `gpii.windows.office.reloadRibbon`: Reloads the ribbon.

--- a/gpii/node_modules/gpii-office/index.js
+++ b/gpii/node_modules/gpii-office/index.js
@@ -1,0 +1,21 @@
+/*
+ * Provides support for Microsoft Office applications.
+ *
+ * Copyright 2019 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+require("./src/ribbon.js");

--- a/gpii/node_modules/gpii-office/package.json
+++ b/gpii/node_modules/gpii-office/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "gpii-office",
+    "description": "Office support for GPII.",
+    "version": "0.3.0",
+    "author": "GPII",
+    "bugs": "http://issues.gpii.net/browse/GPII",
+    "homepage": "http://gpii.net/",
+    "dependencies": {},
+    "license" : "BSD-3-Clause",
+    "repository": "git://github.com/GPII/windows.git",
+    "main": "./index.js",
+    "engines": { "node" : ">=4.2.1" }
+}

--- a/gpii/node_modules/gpii-office/src/reset.xml
+++ b/gpii/node_modules/gpii-office/src/reset.xml
@@ -1,0 +1,8 @@
+<mso:customUI xmlns:mso="http://schemas.microsoft.com/office/2009/07/customui">
+    <mso:ribbon startFromScratch="true">
+        <mso:tabs>
+            <mso:tab id="morphic.basics" visible="false"/>
+            <mso:tab id="morphic.essentials" visible="false"/>
+        </mso:tabs>
+    </mso:ribbon>
+</mso:customUI>

--- a/gpii/node_modules/gpii-office/src/ribbon.js
+++ b/gpii/node_modules/gpii-office/src/ribbon.js
@@ -1,0 +1,77 @@
+/* Reload the ribbon on Office Applications.
+ *
+ * Copyright 2019 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("gpii-universal"),
+    path = require("path"),
+    fs = require("fs"),
+    edge = process.versions.electron ? require("electron-edge-js") : require("edge-js");
+
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.windows.office");
+
+gpii.windows.office.reloadRibbonNative = edge.func({
+    source: path.join(__dirname, "ribbonReload.cs"),
+    typeName: "GPIIOffice.RibbonReload",
+    references: ["System.Runtime.dll"]
+});
+
+/**
+ * Reloads the ribbon for a given Office Application.
+ * @param {String} applicationName Name of the application, such as "Word" or "Excel"
+ * @param {String} targetPath Path of the customUI file.
+ * @param {Object} applicationObject Something that looks like an office automation COM object (for testing)
+ * @return {Promise} Resolves when complete, with a boolean indicating if it succeeded.
+ */
+gpii.windows.office.reloadRibbon = function (applicationName, targetPath, applicationObject) {
+    var promise = fluid.promise();
+
+    fluid.log("Reloading ribbon for " + applicationName);
+
+    if (targetPath && !fs.existsSync(targetPath)) {
+        // When performing a live update, a non-existing file doesn't remove new the items added by the last update.
+        // Set it to a special file to make it reset.
+        fs.copyFileSync(path.join(__dirname, "reset.xml"), targetPath);
+        var cleanup = function () {
+            fs.unlinkSync(targetPath);
+        };
+        promise.then(cleanup, cleanup);
+    }
+
+    gpii.windows.office.reloadRibbonNative({
+        applicationName: applicationName, applicationObject: applicationObject
+    }, function (err, result) {
+        if (err) {
+            fluid.log("ReloadRibbon:", err);
+            promise.reject(err);
+        } else {
+            promise.resolve(result);
+        }
+    });
+
+    return promise;
+};
+
+
+fluid.defaults("gpii.windows.office.reloadRibbon", {
+    gradeNames: "fluid.function",
+    argumentMap: {
+        application: 0,
+        path: 1
+    }
+});

--- a/gpii/node_modules/gpii-office/src/ribbonReload.cs
+++ b/gpii/node_modules/gpii-office/src/ribbonReload.cs
@@ -1,0 +1,126 @@
+/* Reload the ribbon on Office Applications.
+ *
+ * Word (and some other Office applications) only seem to reload the ribbon when changing between different Word
+ * windows. So, if two Word windows are open then WM_ACTIVATE is sent to each one to simulate this. If only a single
+ * window is open then a new one is created and closed before sending WM_ACTIVATE.
+ *
+ * Copyright 2019 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+namespace GPIIOffice
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Threading.Tasks;
+#if GOT_OFFICE
+    // GOT_OFFICE can be defined during development if the Office PIAs are installed.
+    // (Put it in a project and add a reference to Microsoft.Office.Interop.Word)
+    using Word = Microsoft.Office.Interop.Word;
+#endif
+
+    public class RibbonReload
+    {
+        private const int WM_ACTIVATE = 0x6;
+        private const int HWND_TOPMOST = -1;
+        private const int HWND_NOTOPMOST = -2;
+        private const int SWP_NOMOVE = 0x0002;
+        private const int SWP_NOSIZE = 0x0001;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, IntPtr lParam);
+        [DllImport("user32.dll")]
+        private static extern bool SetWindowPos(int hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, int uFlags);
+
+#if STANDALONE
+        static void Main(string[] args)
+        {
+            new RibbonReload().Invoke(new { applicationName = "Word" }).Wait();
+        }
+#endif
+
+        /// <summary>
+        /// Entry point for edge.js
+        /// </summary>
+        /// <param name="input">object containing 'applicationName'</param>
+        /// <returns>true on success</returns>
+        public async Task<object> Invoke(dynamic input)
+        {
+            try
+            {
+                return ReloadRibbon(input.applicationName, input.applicationObject);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Reloads the ribbon for the given Office application.
+        /// </summary>
+        /// <param name="applicationName">The Office application; Word, Excel</param>
+        /// <param name="applicationObject">An instance of a office COM object (for testing)</param>
+        static bool ReloadRibbon(string applicationName, dynamic applicationObject = null)
+        {
+            // Get the running instance.
+#if GOT_OFFICE
+            Word.Application app = Marshal.GetActiveObject("Word.Application") as Word.Application;
+#else
+                dynamic app = applicationObject ?? Marshal.GetActiveObject(applicationName + ".Application");
+#endif
+            if (app == null)
+            {
+                // No instance means nothing to update.
+                return true;
+            }
+
+            int windowCount = app.Windows.Count;
+
+            // A word window will update the ribbon when it has been activated, but only if another Word window was
+            // active sometime earlier.
+
+            // A single window will need another window to be activated first.
+            if (windowCount == 1)
+            {
+#if GOT_OFFICE
+                Word.Window window = app.ActiveWindow;
+#else
+                    dynamic window = app.ActiveWindow;
+#endif
+
+                try
+                {
+                    // Make this window on top of everything, to hide the flicker of the new window.
+                    SetWindowPos(window.Hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    // Create and close a new window
+                    window.NewWindow().Close();
+                }
+                finally
+                {
+                    // Stop the window from being over everything.
+                    SetWindowPos(window.Hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                }
+            }
+
+            // Send a message to each Word window to make it think it's been activated, and therefor reload the Ribbon.
+            for (int i = 0; i < windowCount; i++)
+            {
+                SendMessage((IntPtr)app.Windows[i + 1].Hwnd, WM_ACTIVATE, 1, IntPtr.Zero);
+            }
+
+            return true;
+        }
+    }
+}

--- a/gpii/node_modules/gpii-office/src/ribbonReload.cs
+++ b/gpii/node_modules/gpii-office/src/ribbonReload.cs
@@ -42,6 +42,8 @@ namespace GPIIOffice
         private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, IntPtr lParam);
         [DllImport("user32.dll")]
         private static extern bool SetWindowPos(int hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, int uFlags);
+        [DllImport("user32.dll")]
+        private static extern bool LockSetForegroundWindow(uint uLockCode);
 
 #if STANDALONE
         static void Main(string[] args)
@@ -74,6 +76,9 @@ namespace GPIIOffice
         /// <param name="applicationObject">An instance of a office COM object (for testing)</param>
         static bool ReloadRibbon(string applicationName, dynamic applicationObject = null)
         {
+            // Prevent Word from stealing the focus.
+            LockSetForegroundWindow(1);
+
             // Get the running instance.
 #if GOT_OFFICE
             Word.Application app = Marshal.GetActiveObject("Word.Application") as Word.Application;

--- a/gpii/node_modules/gpii-office/test/ribbonTest.js
+++ b/gpii/node_modules/gpii-office/test/ribbonTest.js
@@ -63,4 +63,3 @@ jqUnit.asyncTest("Testing ribbon reloading - no windows open", function () {
         jqUnit.start();
     }, jqUnit.fail);
 });
-

--- a/gpii/node_modules/gpii-office/test/ribbonTest.js
+++ b/gpii/node_modules/gpii-office/test/ribbonTest.js
@@ -1,0 +1,66 @@
+/*
+ * Tests for ribbon.js
+ *
+ * Copyright 2019 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+require("../../WindowsUtilities/WindowsUtilities.js");
+
+var fluid = require("gpii-universal");
+
+var jqUnit = fluid.require("node-jqunit");
+var gpii = fluid.registerNamespace("gpii");
+
+fluid.registerNamespace("gpii.tests.officeRibbon");
+
+require("../index.js");
+
+jqUnit.module("gpii.tests.officeRibbon");
+
+// Check it fails gracefully if the office automation instance can't be loaded
+jqUnit.asyncTest("Testing ribbon reloading (successful failure)", function () {
+
+    jqUnit.expect(2);
+
+    var promise = gpii.windows.office.reloadRibbon("NoSuchApplication");
+    jqUnit.assertTrue("reloadRibbon must return a promise", fluid.isPromise(promise));
+
+    promise.then(function (value) {
+        jqUnit.assertFalse("Failing to access Office should resolve with false", value);
+        jqUnit.start();
+    }, jqUnit.fail);
+});
+
+// Perform a (sort of) successful run.
+jqUnit.asyncTest("Testing ribbon reloading - no windows open", function () {
+
+    jqUnit.expect(2);
+    var officeObject = {
+        Windows: {
+            Count: 0
+        }
+    };
+
+    var promise = gpii.windows.office.reloadRibbon("TestApplication", null, officeObject);
+    jqUnit.assertTrue("reloadRibbon must return a promise", fluid.isPromise(promise));
+
+    promise.then(function (value) {
+        jqUnit.assertTrue("reloadRibbon should resolve with true", value);
+        jqUnit.start();
+    }, jqUnit.fail);
+});
+

--- a/index.js
+++ b/index.js
@@ -46,5 +46,6 @@ require("./gpii/node_modules/nativeSettingsHandler");
 require("./gpii/node_modules/gpii-app-zoom");
 require("./gpii/node_modules/wmiSettingsHandler");
 require("./gpii/node_modules/gpii-localisation");
+require("./gpii/node_modules/gpii-office");
 
 module.exports = fluid;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "edge-js": "10.3.1",
         "ffi-napi": "2.4.3",
-        "gpii-universal": "stegru/universal#GPII-3927",
+        "gpii-universal": "0.3.0-dev.20190801T142013Z.3e58c798",
         "@pokusew/pcsclite": "0.4.18",
         "ref": "1.3.4",
         "ref-struct": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "edge-js": "10.3.1",
         "ffi-napi": "2.4.3",
-        "gpii-universal": "0.3.0-dev.20190529T130102Z.a3fea390",
+        "gpii-universal": "stegru/universal#GPII-3927",
         "@pokusew/pcsclite": "0.4.18",
         "ref": "1.3.4",
         "ref-struct": "1.1.0",

--- a/tests/UnitTests.js
+++ b/tests/UnitTests.js
@@ -33,3 +33,4 @@ require("../gpii/node_modules/windowMessages/test/windowMessagesTest.js");
 require("../gpii/node_modules/windowsMetrics/test/WindowsMetricsTests.js");
 require("../gpii/node_modules/windowsUtilities/test/WindowsUtilitiesTests.js");
 require("../gpii/node_modules/wmiSettingsHandler/test/testWmiSettingsHandler.js");
+require("../gpii/node_modules/gpii-office/test/ribbonTest.js");


### PR DESCRIPTION
This contains the code to update the ribbon on Office applications.

@Karadaliev, I've made enough progress on the office simplification for you to start working with it. At the moment, it only performs the file swapping and doesn't restart Word.

If you point your reference of gpii-windows to this branch, `stegru/windows#GPII-3927`, it will pull in the branch of universal I'm working on.

I'm guessing this will be implemented in a similar way that the high-contrast or screen-scale widgets speak with core, the preference is `http://registry\.gpii\.net/applications/com\.microsoft.office` (the final `.` is not escaped).

The values can be one of the following, depending on the checkbox values:
`StandardSet`
`Basics+StandardSet`
`Essentials+StandardSet`
`Basics+Essentials+StandardSet`

(if that's tricky to implement in the widgets, another method can be used - such as 0-4).

