### PR TITLE
GPII-4011: Showing the volume change on the screen

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -517,6 +517,8 @@ windows.API_constants = {
     WM_DISPLAYCHANGE: 0x7e,
     // https://docs.microsoft.com/windows/desktop/winmsg/wm-themechanged
     WM_THEMECHANGED: 0x31a,
+    // https://docs.microsoft.com/windows/win32/inputdev/wm-appcommand
+    WM_APPCOMMAND: 0x319,
 
 
     // https://msdn.microsoft.com/library/aa363205
@@ -525,6 +527,10 @@ windows.API_constants = {
     DBT_DEVICEREMOVEPENDING: 0x8003,
     DBT_DEVICEREMOVECOMPLETE: 0x8004,
     DBT_DEVTYP_VOLUME: 0x2,
+
+    // https://docs.microsoft.com/windows/win32/inputdev/wm-appcommand
+    APPCOMMAND_VOLUME_DOWN: 9,
+    APPCOMMAND_VOLUME_UP: 10,
 
     // https://msdn.microsoft.com/library/dd375731
     virtualKeyCodes: {

--- a/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
+++ b/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
@@ -11,6 +11,7 @@
 // Operation constants
 const wchar_t* Get = L"Get";
 const wchar_t* Set = L"Set";
+const wchar_t* SetNear = L"SetNear";
 
 int wmain(int argc, wchar_t *argv[]) {
     // Payload
@@ -39,7 +40,7 @@ int wmain(int argc, wchar_t *argv[]) {
 
         value = std::wcstof(start, &end);
 
-        if (operation != Set || (value == 0 && end == start)) {
+        if ((operation != Set && operation != SetNear) || (value == 0 && end == start)) {
             std::wcout <<  L"{ \"code\": \"160\", \"message\": \"EINVAL\" }";
             return 0;
         }
@@ -85,13 +86,31 @@ int wmain(int argc, wchar_t *argv[]) {
             std::wcout << L"{ \"Value\": \"" << std::to_wstring(curVolume) << "\" }";
         }
     } else {
-        float curVolume = 0;
-        hr = pEndpointVolume->SetMasterVolumeLevelScalar(value, NULL);
+		float curVolume = 0;
+		hr = pEndpointVolume->GetMasterVolumeLevelScalar(&curVolume);
+
+		if (operation == SetNear && hr == S_OK) {
+			// Set the volume to near the target volume, allowing a small amount for the UI to finish the job.
+			if (abs(value - curVolume) > 0.02) {
+				value += (value > curVolume) ? -0.02 : 0.02;
+			} else  {
+				value = curVolume;
+			}
+		}
+
+		if (operation == Set || value != curVolume) {
+			hr = pEndpointVolume->SetMasterVolumeLevelScalar(value, NULL);
+		}
 
         if (hr != S_OK) {
             std::wcout << L"{ \"code\": \"" << std::to_wstring(hr) << "\", \"message\": \"Failed to set current system volume\" }";
         } else {
-            std::wcout << L"{ \"Value\": \"" << std::to_wstring(curVolume) << "\" }";
+			float newVolume = 0;
+			if (pEndpointVolume->GetMasterVolumeLevelScalar(&newVolume) != S_OK) {
+				newVolume = value;
+			}
+			std::wcout << L"{ \"Value\": \"" << std::to_wstring(newVolume) << "\", \"Old\": \""
+				<< std::to_wstring(curVolume) << "\" }";
         }
     }
 

--- a/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
+++ b/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
@@ -87,6 +87,7 @@ int wmain(int argc, wchar_t *argv[]) {
         }
     } else {
 		float curVolume = 0;
+
 		hr = pEndpointVolume->GetMasterVolumeLevelScalar(&curVolume);
 
 		if (operation == SetNear && hr == S_OK) {

--- a/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
+++ b/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.cpp
@@ -87,7 +87,6 @@ int wmain(int argc, wchar_t *argv[]) {
         }
     } else {
 		float curVolume = 0;
-
 		hr = pEndpointVolume->GetMasterVolumeLevelScalar(&curVolume);
 
 		if (operation == SetNear && hr == S_OK) {

--- a/gpii/node_modules/nativeSettingsHandler/src/nativeSettingsHandler.js
+++ b/gpii/node_modules/nativeSettingsHandler/src/nativeSettingsHandler.js
@@ -164,7 +164,8 @@ windows.nativeSettingsHandler.SetDoubleClickHeight = function (num) {
 /**
  * Function that handles calling the native executable for volume control.
  *
- * @param {String} mode The operation mode, could be either "Set" or "Get".
+ * @param {String} mode The operation mode, could be either "Set", "SetNear" or "Get". Calling with "SetNear" will
+ *   adjust the volume so it's near the target volume, allowing room for the shell to do the rest.
  * @param {Number} [num] The value to set as the current system volume. Range is normalized from 0 to 1.
  * @return {Promise} A promise that resolves on success or holds a object with the error information.
  */
@@ -176,9 +177,9 @@ windows.nativeSettingsHandler.VolumeHandler = function (mode, num) {
         var valueBuff;
 
         if (mode === "Get") {
-            valueBuff = child_process.execFileSync(fileName, ["Get"], {});
+            valueBuff = child_process.execFileSync(fileName, [mode], {});
         } else {
-            valueBuff = child_process.execFileSync(fileName, ["Set", num], {});
+            valueBuff = child_process.execFileSync(fileName, [mode, num], {});
         }
 
         var strRes = valueBuff.toString("utf8");
@@ -215,7 +216,18 @@ windows.nativeSettingsHandler.GetVolume = function () {
  * @return {Promise} A promise that resolves on success or holds a object with the error information.
  */
 windows.nativeSettingsHandler.SetVolume = function (num) {
-    return windows.nativeSettingsHandler.VolumeHandler("Set", num);
+    return windows.nativeSettingsHandler.VolumeHandler("SetNear", num).then(function (result) {
+        var current = parseFloat(result);
+        if (current !== num) {
+            // Complete the last bit of the change, as though the media keys where used, in order to show the new volume
+            // on the screen.
+            var action = current < num
+                ? windows.API_constants.APPCOMMAND_VOLUME_UP : windows.API_constants.APPCOMMAND_VOLUME_DOWN;
+            // Send the volume up/down command directly to the task tray (rather than a simulated key press)
+            gpii.windows.messages.sendMessage("Shell_TrayWnd", windows.API_constants.WM_APPCOMMAND, 0,
+                windows.makeLong(0, action));
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
This sets the volume to almost the required value, then uses the shell to perform the final increment causing the volume to show on screen.

The diff shown for [VolumeControl.cpp](https://github.com/GPII/windows/compare/master...stegru:GPII-4011?expand=1#diff-4b8f65b352dd4b891144769e3d5d6b84) is exaggerated, so here's a picture of the real changes:
![VolumeControl.cpp](http://i.imgur.com/l6Izpen.png)