### PR TITLE
GPII-4079: Start a process while specifying the initial window state.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -74,7 +74,8 @@ windows.types = {
     // support both modes.
     // https://msdn.microsoft.com/en-us/library/windows/desktop/dd374131(v=vs.85).aspx
     "TCHAR": "uint16",
-    "PTCHAR": ref.refType("uint16")
+    "PTCHAR": ref.refType("uint16"),
+    "LP":    "void*"
 };
 
 var t = windows.types;
@@ -181,6 +182,21 @@ windows.kernel32 = ffi.Library("kernel32", {
     // https://msdn.microsoft.com/library/aa363858
     "CreateFileW": [
         t.HANDLE, [ "char*", t.DWORD, t.DWORD, t.HANDLE, t.DWORD, t.DWORD, t.HANDLE ]
+    ],
+    // https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
+    "CreateProcessW": [
+        t.BOOL, [
+            "char*",   // LPCTSTR               lpApplicationName,
+            "char*",   // LPTSTR                lpCommandLine,
+            t.LP,      // LPSECURITY_ATTRIBUTES lpProcessAttributes,
+            t.LP,      // LPSECURITY_ATTRIBUTES lpThreadAttributes,
+            t.BOOL,    // BOOL                  bInheritHandles,
+            t.DWORD,   // DWORD                 dwCreationFlags,
+            t.LP,      // LPVOID                lpEnvironment,
+            t.LP,      // LPCTSTR               lpCurrentDirectory,
+            t.LP,      // LPSTARTUPINFO         lpStartupInfo,
+            t.LP       // LPPROCESS_INFORMATION lpProcessInformation
+        ]
     ]
 });
 
@@ -629,7 +645,18 @@ windows.API_constants = {
 
     SM_SWAPBUTTON: 23,
 
-    INVALID_HANDLE_VALUE: 0xffffffff
+    INVALID_HANDLE_VALUE: 0xffffffff,
+
+    // https://docs.microsoft.com/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+    STARTF_USESHOWWINDOW: 0x1,
+    // https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-showwindow
+    SW_HIDE: 0,
+    SW_SHOWNORMAL: 1,
+    SW_SHOWMINIMIZED: 2,
+    SW_SHOWMAXIMIZED: 3,
+    SW_SHOWNOACTIVATE: 4
+
+
 };
 
 fluid.each(windows.API_constants.returnCodesLookup, function (value, key) {
@@ -831,6 +858,36 @@ windows.COPYDATASTRUCT = new Struct([
     ["int", "dwData"],
     [t.DWORD, "cbData"],
     ["void*", "lpData"]
+]);
+
+// https://docs.microsoft.com/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+windows.STARTUPINFO = new Struct([
+    [t.DWORD, "cb"],
+    ["char*", "lpReserved"],
+    ["char*", "lpDesktop"],
+    ["char*", "lpTitle"],
+    [t.DWORD, "dwX"],
+    [t.DWORD, "dwY"],
+    [t.DWORD, "dwXSize"],
+    [t.DWORD, "dwYSize"],
+    [t.DWORD, "dwXCountChars"],
+    [t.DWORD, "dwYCountChars"],
+    [t.DWORD, "dwFillAttribute"],
+    [t.DWORD, "dwFlags"],
+    [t.WORD, "wShowWindow"],
+    [t.WORD, "cbReserved2"],
+    [t.LP, "lpReserved2"],
+    [t.HANDLE, "hStdInput"],
+    [t.HANDLE, "hStdOutput"],
+    [t.HANDLE, "hStdError"]
+]);
+
+// https://msdn.microsoft.com/library/ms684873
+windows.PROCESS_INFORMATION = new Struct([
+    [t.HANDLE, "hProcess"],
+    [t.HANDLE, "hThread"],
+    [t.DWORD, "dwProcessId"],
+    [t.DWORD, "dwThreadId"]
 ]);
 
 /**

--- a/gpii/node_modules/processHandling/processHandling.js
+++ b/gpii/node_modules/processHandling/processHandling.js
@@ -537,6 +537,63 @@ gpii.windows.restartExplorer = function (options) {
     return fluid.promise.sequence(work, options);
 };
 
+/**
+ * Starts a process.
+ *
+ * Use this in favour of built-in child_process functions only if controlling the initial window is desired.
+ *
+ * Not all processes will honour the initial window state value.
+ *
+ * @param {String} executable The executable path.
+ * @param {String|Array<String>} args The arguments (passed directly to the process, with no shell expansion).
+ * @param {Object} options [optional] Options
+ * @param {String} options.windowState The state of the process's first window. "hide", "normal", "minimized",
+ *   "maximized", or "noactivate".
+ *
+ * @return {Number} The pid of the new process.
+ */
+gpii.windows.startProcess = function (executable, args, options) {
+
+    var argArray = fluid.makeArray(args);
+    // Quote the executable name, in case it contains spaces
+    argArray.unshift("\"" + executable + "\"");
+    var commandLine = windows.stringToWideChar(argArray.join(" "));
+
+    var showWindow = ({
+        hide: gpii.windows.API_constants.SW_HIDE,
+        normal: gpii.windows.API_constants.SW_SHOWNORMAL,
+        minimized: gpii.windows.API_constants.SW_SHOWMINIMIZED,
+        maximized: gpii.windows.API_constants.SW_SHOWMAXIMIZED,
+        noactivate: gpii.windows.API_constants.SW_SHOWNOACTIVATE
+    })[options && options.windowState];
+
+    var startupInfo = new windows.STARTUPINFO();
+    startupInfo.ref().fill(0);
+    startupInfo.cb = windows.STARTUPINFO.size;
+
+    if (showWindow !== undefined) {
+        startupInfo.dwFlags |= windows.API_constants.STARTF_USESHOWWINDOW;
+        startupInfo.wShowWindow = showWindow;
+    }
+
+    var processInfoBuf = new windows.PROCESS_INFORMATION();
+    processInfoBuf.ref().fill(0);
+
+    var ret = windows.kernel32.CreateProcessW(ref.NULL, commandLine, ref.NULL, ref.NULL, 0, 0,
+        ref.NULL, ref.NULL, startupInfo.ref(), processInfoBuf.ref());
+
+    if (!ret) {
+        var errorText = windows.win32errorText("CreateProcessW", ret);
+        fluid.log("Trouble starting '" + argArray.join(" ") + "': ", errorText);
+    }
+
+    windows.kernel32.CloseHandle(processInfoBuf.hThread);
+    windows.kernel32.CloseHandle(processInfoBuf.hProcess);
+
+    return ret ? processInfoBuf.dwProcessId : 0;
+
+};
+
 fluid.defaults("gpii.windows.stopExplorer", {
     gradeNames: "fluid.function",
     argumentMap: {}

--- a/gpii/node_modules/processHandling/test/test-window.cs
+++ b/gpii/node_modules/processHandling/test/test-window.cs
@@ -21,7 +21,9 @@
 namespace TestWindow
 {
     using System;
+    using System.IO;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Windows.Forms;
 
     public class TestWindow : Form
@@ -44,6 +46,10 @@ namespace TestWindow
                 };
                 Application.Run(window);
                 Console.WriteLine("test-window: Ended");
+            }
+            else if (args.FirstOrDefault() == "-windowState")
+            {
+                WriteStartup(args[1]);
             }
             else
             {
@@ -79,5 +85,38 @@ namespace TestWindow
 
             Console.WriteLine("test-window: Window created. hwnd=" + this.Handle);
         }
+
+        private static void WriteStartup(string file)
+        {
+            STARTUPINFO startupInfo;
+            GetStartupInfo(out startupInfo);
+            File.WriteAllText(file, startupInfo.wShowWindow.ToString());
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        public struct STARTUPINFO
+        {
+            public uint cb;
+            public string lpReserved;
+            public string lpDesktop;
+            public string lpTitle;
+            public uint dwX;
+            public uint dwY;
+            public uint dwXSize;
+            public uint dwYSize;
+            public uint dwXCountChars;
+            public uint dwYCountChars;
+            public uint dwFillAttribute;
+            public uint dwFlags;
+            public ushort wShowWindow;
+            public ushort cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public IntPtr hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "GetStartupInfoA")]
+        public static extern void GetStartupInfo(out STARTUPINFO lpStartupInfo);
     }
 }

--- a/gpii/node_modules/processHandling/test/testProcessHandling.js
+++ b/gpii/node_modules/processHandling/test/testProcessHandling.js
@@ -22,6 +22,8 @@ var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 var shelljs = require("shelljs"),
     path = require("path"),
+    os = require("os"),
+    fs = require("fs"),
     child_process = require("child_process");
 
 require("../processHandling.js");
@@ -363,4 +365,68 @@ jqUnit.test("Testing getProcessPath", function () {
     // Try the "System" process.
     var path2 = gpii.windows.getProcessPath(4);
     jqUnit.assertEquals("Path for explorer be correct", "system", path2.toLowerCase());
+});
+
+// Test startProcess starts the process with the correct window state.
+jqUnit.asyncTest("Testing startProcess", function () {
+
+    var exeName = "test-window.exe";
+    var exePath = path.join(__dirname, exeName);
+
+    var tests = [
+        {
+            windowState: "hide",
+            expect: gpii.windows.API_constants.SW_HIDE
+        }, {
+            windowState: "normal",
+            expect: gpii.windows.API_constants.SW_SHOWNORMAL
+        }, {
+            windowState: "minimized",
+            expect: gpii.windows.API_constants.SW_SHOWMINIMIZED
+        }, {
+            windowState: "maximized",
+            expect: gpii.windows.API_constants.SW_SHOWMAXIMIZED
+        }, {
+            windowState: "noactivate",
+            expect: gpii.windows.API_constants.SW_SHOWNOACTIVATE
+        }
+    ];
+
+    jqUnit.expect(tests.length * 3);
+    var tempFiles = [];
+    teardowns.push(function () {
+        shelljs.rm(tempFiles);
+    });
+
+    var runTest = function (testIndex) {
+        var test = tests[testIndex];
+        if (!test) {
+            jqUnit.start();
+            return;
+        }
+
+        var tempFile = path.join(os.tmpdir(), "gpii-startprocess" + Math.random());
+        tempFiles.push(tempFile);
+
+        var p = gpii.windows.startProcess(exePath, ["-windowState", tempFile], {windowState: test.windowState});
+        jqUnit.assertEquals("startProcess should return a number", "number", typeof(p));
+        jqUnit.assertTrue("startProcess should return a process ID", p > 0);
+
+        gpii.windows.waitForProcessTermination(p, 15000).then(function (result) {
+
+            if (result === "timeout") {
+                jqUnit.fail("Timeout waiting for test-window.exe to finish");
+            }
+
+            var actualWindowState = parseInt(fs.readFileSync(tempFile, "utf8"));
+
+            jqUnit.assertEquals("wShowWindow in the child window must be the expected value",
+                test.expect, actualWindowState);
+
+            runTest(testIndex + 1);
+
+        }, jqUnit.fail);
+    };
+
+    runTest(0);
 });


### PR DESCRIPTION
This provides `gpii.windows.startProcess`, which can start a new process with the instruction to set the initial window to a given state of minimised, maximised, inactive, or hidden.

Not every application honours this. With Chrome in particular, it only works if there is not already a chrome instance running. I might update this branch to work around it, if feasible.

It's equivalent to the *Run* option in the executable's property dialog:

![image](https://user-images.githubusercontent.com/1867587/63790162-a48e3480-c8f0-11e9-93fc-40954a054260.png)
