### PR TITLE
GPII-4186: Using windows certificate store for certificates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,13 @@ fluid.contextAware.makeChecks({
 var binPath = path.join(__dirname, "bin");
 process.env.path = binPath + ";" + process.env.path;
 
+// Use certificates from the Windows certificate stores [GPII-4186]
+var ca = require("win-ca/api");
+ca({
+    store: ["MY", "Root", "Trust", "CA"],
+    inject: "+"
+});
+
 require("./gpii/node_modules/WindowsUtilities/WindowsUtilities.js");
 require("./gpii/node_modules/processHandling/processHandling.js");
 require("./gpii/node_modules/displaySettingsHandler");

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "ref-struct": "1.1.0",
         "ref-array": "1.1.2",
         "string-argv": "0.0.2",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.2",
+        "win-ca": "^3.1.0"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "ref-array": "1.1.2",
         "string-argv": "0.0.2",
         "rimraf": "2.6.2",
-        "win-ca": "^3.1.0"
+        "win-ca": "3.1.1"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.3.0",


### PR DESCRIPTION
Fixes a problem where the Office ribbon wasn't being downloaded (`SELF_SIGNED_CERT_IN_CHAIN`).

This was due to it being run behind an invasive https proxy, and node using a hard-coded list of CA certificates, rather than those provided by the OS.

This fix instructs node to use the Windows certificate store, which means certificates that the administrator has added are also trusted. In other words, if it works in the browser it will work with node.

Unsure why https connections to the gpii cloud still worked, however.

*To reproduce:*
* Get the root certificate for `untrusted-root.badssl.com`, and add it to the *Trusted Root Certifications Authorities* certificate store. (remove it after)
* In [win32.json](https://github.com/GPII/universal/blob/master/testData/solutions/win32.json5#L16132-L16132) Replace `raw.githubusercontent.com` with `untrusted-root.badssl.com` and key-in as `otis`
* or set GPII_CLOUD_URL to `https://untrusted-root.badssl.com`

There will be an error of `SELF_SIGNED_CERT_IN_CHAIN` in the log. After applying this fix, there will be a `404` error (meaning https is working).
