### PR TITLE
GPII-4343: Saving the default theme if the current theme is unknown.

### DIFF
--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -518,7 +518,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
-    if (saveAs) {
+    if (saveAs && saveAs.endsWith("Morphic.theme")) {
         gpii.windows.spiSettingsHandler.saveTheme(currentThemeFile, saveAs);
     }
 

--- a/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
+++ b/gpii/node_modules/spiSettingsHandler/src/SpiSettingsHandler.js
@@ -518,7 +518,7 @@ gpii.windows.spi.GPII1873_HighContrastBug = function (method, payload, results) 
  * @return {String} The display name of the theme specified in the .theme file.
  */
 gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, currentThemeFile, saveAs, dryRun) {
-    if (currentThemeFile && saveAs) {
+    if (saveAs) {
         gpii.windows.spiSettingsHandler.saveTheme(currentThemeFile, saveAs);
     }
 
@@ -566,15 +566,15 @@ gpii.windows.spiSettingsHandler.setHighContrastTheme = function (newThemeFile, c
  * @param {String} saveAs The temporary .theme file to which the current theme is saved.
  */
 gpii.windows.spiSettingsHandler.saveTheme = function (currentThemeFile, saveAs) {
-    var themeData = gpii.iniFile.readFile(currentThemeFile);
+    var themeData = currentThemeFile && gpii.iniFile.readFile(currentThemeFile);
     fluid.log("Saving theme from " + currentThemeFile);
-    var isValid = !!(themeData.MasterThemeSelector && themeData.MasterThemeSelector.MTSM);
+    var isValid = themeData && !!(themeData.MasterThemeSelector && themeData.MasterThemeSelector.MTSM);
     if (!isValid) {
         fluid.log("Theme file invalid.");
         // If the theme file isn't valid, load the default one.
         var defaultTheme = path.join(process.env.SystemRoot, "resources/Themes/aero.theme");
         if (currentThemeFile !== defaultTheme) {
-            gpii.windows.spiSettingsHandler.saveTheme(defaultTheme);
+            gpii.windows.spiSettingsHandler.saveTheme(defaultTheme, saveAs);
         }
     } else if (!themeData.VisualStyles || !themeData.VisualStyles.HighContrast) {
         // Only save the current theme if it is not high-contrast. Otherwise, when changing the high-contrast theme

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -14,7 +14,7 @@ $msbuild = Get-MSBuild "4.0"
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
-Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
+Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`"" $settingsHelperDir
 
 $volumeControlDir = Join-Path $rootDir "gpii\node_modules\nativeSettingsHandler\nativeSolutions\VolumeControl"
 Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir


### PR DESCRIPTION
Fixes the fault found in AJC3 where the high-contrast setting wasn't being restored.

To test: Unset `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes@CurrentTheme`, it should still work.