### PR TITLE
GPII-4353: Using 'exit' event of process, instead of 'close'.

### DIFF
--- a/gpii-service/tests/processHandling-tests.js
+++ b/gpii-service/tests/processHandling-tests.js
@@ -291,7 +291,7 @@ jqUnit.asyncTest("Test isProcessRunning", function () {
             }
         }
 
-        child.on("close", function () {
+        child.on("exit", function () {
             setTimeout(function () {
                 running = processHandling.isProcessRunning(child.pid);
                 jqUnit.assertFalse("Child process should not be running after kill" + assertSuffix, running);

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -14,7 +14,7 @@ $msbuild = Get-MSBuild "4.0"
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
-Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
+Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`"" $settingsHelperDir
 
 $volumeControlDir = Join-Path $rootDir "gpii\node_modules\nativeSettingsHandler\nativeSolutions\VolumeControl"
 Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir


### PR DESCRIPTION
More asserts where being run than expected.

Perhaps due to the `close` event of a `ChildProcess` being raised more than once - perhaps for each standard io stream?  Let's see if the more appropriate `exit` event is better.
