### PR TITLE
GPII-4355: Updated build scripts and projects to use VS2017 build tools

### DIFF
--- a/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.vcxproj
+++ b/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/VolumeControl.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/pch.h
+++ b/gpii/node_modules/nativeSettingsHandler/nativeSolutions/VolumeControl/VolumeControl/pch.h
@@ -11,4 +11,11 @@
 
 // TODO: add headers that you want to pre-compile here
 
+/* NOTE: we declare IUnknown here to satisfy VS2017's compiler's conformant mode (using header files from the Windows 8.1 SDK)
+ * Link: https://developercommunity.visualstudio.com/content/problem/185399/error-c2760-in-combaseapih-with-windows-sdk-81-and.html
+ *       note Stale L. Hansen's recommendation (after reviewing the full thread)
+ * [the alternative remedies are to either turn off conformant mode in the compiler for this project...or update to the Windows 10 SDK] */
+// Workaround for "combaseapi.h(229): error C2187: syntax error: 'identifier' was unexpected here" when using VS2017 compiler with "/permissive-" flag
+struct IUnknown; 
+
 #endif //PCH_H

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "edge-js": "10.3.1",
         "ffi-napi": "2.4.3",
-        "gpii-universal": "0.3.0-dev.20200128T170154Z.eaac9112e",
+        "gpii-universal": "JavierJF/universal#GPII-3810",
         "@pokusew/pcsclite": "0.4.18",
         "ref": "1.3.4",
         "ref-struct": "1.1.0",

--- a/provisioning/Npm.ps1
+++ b/provisioning/Npm.ps1
@@ -13,7 +13,7 @@ Import-Module "$($originalBuildScriptPath)/Provisioning.psm1" -Force
 
 $npm = "npm" -f $env:SystemDrive
 
-Invoke-Command $npm "config set msvs_version 2015 --global"
+Invoke-Command $npm "config set msvs_version 2017 --global"
 Invoke-Command $npm "install grunt-cli -g"
 Invoke-Command $npm "install testem -g"
 refreshenv

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -7,17 +7,26 @@ $VerbosePreference = "continue"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $rootDir = Split-Path -Parent $scriptDir
 
+if (${Env:ProgramFiles(x86)}) {
+  $programFilesX86Path = ${Env:ProgramFiles(x86)}
+} else {
+  # This is required for compatibility with Intel 32-bit systems (since the ProgramFiles(x86) environment variable does not exist on 32-bit Windows)
+  $programFilesX86Path = ${Env:ProgramFiles}
+}
+$programFilesPath = ${Env:ProgramFiles}
+
 # Include main Provisioning module.
 Import-Module (Join-Path $scriptDir 'Provisioning.psm1') -Force -Verbose
 
-$msbuild = Get-MSBuild "4.0"
+# Capture the full file path of MSBuild; we will accept any version >=15.0 and <16.0 (i.e. VS2017)
+$msbuild = Get-MSBuild "[15.0,16.0)"
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
-Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
+Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\$($programFilesX86Path)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
 
 $volumeControlDir = Join-Path $rootDir "gpii\node_modules\nativeSettingsHandler\nativeSolutions\VolumeControl"
-Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir
+Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"$($programFilesX86Path)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir
 
 # Build the process test helper
 $testProcessHandlingDir = Join-Path $rootDir "gpii\node_modules\processHandling\test"

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -23,7 +23,7 @@ $msbuild = Get-MSBuild "[15.0,16.0)"
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
-Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\$($programFilesX86Path)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
+Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"$($programFilesX86Path)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $settingsHelperDir
 
 $volumeControlDir = Join-Path $rootDir "gpii\node_modules\nativeSettingsHandler\nativeSolutions\VolumeControl"
 Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"$($programFilesX86Path)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -18,8 +18,14 @@ $programFilesPath = ${Env:ProgramFiles}
 # Include main Provisioning module.
 Import-Module (Join-Path $scriptDir 'Provisioning.psm1') -Force -Verbose
 
-# Capture the full file path of MSBuild; we will accept any version >=15.0 and <16.0 (i.e. VS2017)
-$msbuild = Get-MSBuild "[15.0,16.0)"
+# For Microsoft's build tools, we will accept any version >=15.0 and <16.0 (i.e. VS2017)
+$visualStudioVersion = "[15.0,16.0)"
+
+# Capture the full file path of MSBuild 
+$msbuild = Get-MSBuild $visualStudioVersion
+
+# Capture the full file path of the C# compiler
+$csc = Get-CSharpCompiler $visualStudioVersion
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
@@ -30,7 +36,6 @@ Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=
 
 # Build the process test helper
 $testProcessHandlingDir = Join-Path $rootDir "gpii\node_modules\processHandling\test"
-$csc = Join-Path -Path (Split-Path -Parent $msbuild) csc.exe
 Invoke-Command $csc "/target:exe /out:test-window.exe test-window.cs" $testProcessHandlingDir
 
 # Build the Windows Service


### PR DESCRIPTION
This PR, combined with the gpii-app/GPII-4355 PR, should fully enable Morphic for Windows to compile using modern (VS2017) developer tools and Node.js v10.16.3.

Please note that this branch is based on the current "master" branch of GPII/windows (which contains a bug which is preventing most of the "set" Settings Handlers from working).  However it should be able to be merged with any recent production-quality commit in the master branch.

Critical: developers must upgrade their developer environment to Visual Studio 2017.  The new build scripts use Microsoft's new "vswhere" utility (included with VS2017+) to locate MSBuild, CSC, environment variables, etc.  This is a hard fork in the road...and we will need all the developers on our team (plus the CI environment) to move to VS2017 when this goes "live" in master.

For the future: The $visualStudioVersion PowerShell variable has been designed to support either a specific version (e.g. "15.0" for VS2017) or a range (e.g. "[15.0,16.0)" as an inclusive range for any VS2017'ish releases from v15.0 to v15.9999999999).  This means that as we want to start adding support for VS2019 or other newer releases, we can simplly update the $visualStudioVersion variable to include a wider range of compiler versions.  Our build may indeed be compatible with VS2019 as well, but I have not tested with VS2019 due to the fact that Electron still uses VS2017 in their documentation.