### PR TITLE
GPII-4367: Re-added the frameworkPathOverride to NpmInstall.ps1

### DIFF
--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -14,10 +14,10 @@ $msbuild = Get-MSBuild "4.0"
 
 # Build the settings helper
 $settingsHelperDir = Join-Path $rootDir "settingsHelper"
-Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`"" $settingsHelperDir
+Invoke-Command $msbuild "SettingsHelper.sln /p:Configuration=Release /p:Platform=`"Any CPU`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1`"" $settingsHelperDir
 
 $volumeControlDir = Join-Path $rootDir "gpii\node_modules\nativeSettingsHandler\nativeSolutions\VolumeControl"
-Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $volumeControlDir
+Invoke-Command $msbuild "VolumeControl.sln /p:Configuration=Release /p:Platform=`"x86`" /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1`"" $volumeControlDir
 
 # Build the process test helper
 $testProcessHandlingDir = Join-Path $rootDir "gpii\node_modules\processHandling\test"


### PR DESCRIPTION
And updated according to the currently installed version of the .Net
framework in the windows vagrant box (2020.02.11)