### PR TITLE
GPII-4365: Language test improvements

### DIFF
--- a/gpii/node_modules/gpii-app-zoom/test/testAppZoom.js
+++ b/gpii/node_modules/gpii-app-zoom/test/testAppZoom.js
@@ -23,9 +23,6 @@ var gpii = fluid.registerNamespace("gpii");
 
 var ffi = require("ffi-napi");
 
-require("../../../../index.js");
-fluid.require("%gpii-windows");
-
 require("../src/appZoom.js");
 require("../../../../tests/TestWithMocks.js");
 

--- a/gpii/node_modules/gpii-localisation/src/language.js
+++ b/gpii/node_modules/gpii-localisation/src/language.js
@@ -232,7 +232,7 @@ gpii.windows.language.getLanguageNames = function (that, langCodes) {
         promise.resolve(languages);
     });
 
-    child.on("exit", function () {
+    child.on("exit", function (code) {
         if (timer) {
             clearTimeout(timer);
         }
@@ -241,7 +241,9 @@ gpii.windows.language.getLanguageNames = function (that, langCodes) {
             fluid.log("languageNames failed");
             promise.reject({
                 isError: true,
-                message: "Timed out waiting for the language names"
+                message: timer
+                    ? "language name translation failed (" + code + ")"
+                    : "Timed out waiting for the language names"
             });
         }
     });

--- a/gpii/node_modules/gpii-localisation/src/languageNames.js
+++ b/gpii/node_modules/gpii-localisation/src/languageNames.js
@@ -138,4 +138,9 @@ langCodes.forEach(function (langCode) {
     result[langCode] = getLanguageNames(langCode);
 });
 
-process.send(result);
+process.send(result, function (err) {
+    if (err) {
+        console.error("Failed to send language names", err);
+    }
+    process.exit(err ? 1 : 0);
+});

--- a/gpii/node_modules/gpii-localisation/test/testLanguage.js
+++ b/gpii/node_modules/gpii-localisation/test/testLanguage.js
@@ -23,8 +23,6 @@ var fluid = require("gpii-universal");
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
-fluid.require("%gpii-windows");
-
 require("../src/language.js");
 
 fluid.registerNamespace("gpii.tests.windows.language");

--- a/gpii/node_modules/gpii-localisation/test/testLanguage.js
+++ b/gpii/node_modules/gpii-localisation/test/testLanguage.js
@@ -19,13 +19,14 @@
 "use strict";
 
 var fluid = require("gpii-universal");
-
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
 require("../src/language.js");
 
 fluid.registerNamespace("gpii.tests.windows.language");
+
+jqUnit.module("Language tests");
 
 // Tests for getLanguageNames();
 // Language code casing tests (from https://tools.ietf.org/html/rfc5646#appendix-A)
@@ -305,7 +306,7 @@ jqUnit.asyncTest("Test getting language names", function () {
                         test.expect, result);
                 }
                 doTest(testIndex + 1);
-            }, jqUnit.fail);
+            }, fluid.fail);
         } else {
             language.destroy();
             jqUnit.start();
@@ -364,6 +365,6 @@ jqUnit.asyncTest("Test getting installed languages", function () {
 
             language.destroy();
             jqUnit.start();
-        }, jqUnit.fail);
-    }, jqUnit.fail);
+        }, fluid.fail);
+    }, fluid.fail);
 });

--- a/gpii/node_modules/gpii-userInput/test/testSendKeys.js
+++ b/gpii/node_modules/gpii-userInput/test/testSendKeys.js
@@ -23,8 +23,6 @@ var fluid = require("gpii-universal");
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
-fluid.require("%gpii-windows");
-
 require("../src/sendKeys.js");
 
 fluid.registerNamespace("gpii.tests.windows.sendKeys");

--- a/gpii/node_modules/gpii-windowManagement/test/appBarTests.js
+++ b/gpii/node_modules/gpii-windowManagement/test/appBarTests.js
@@ -26,8 +26,6 @@ kettle.loadTestingSupport();
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
-fluid.require("%gpii-windows");
-
 require("../src/appBar.js");
 
 fluid.registerNamespace("gpii.tests.windows.appBar");

--- a/gpii/node_modules/nativeSettingsHandler/test/testNativeSettingsHandler.js
+++ b/gpii/node_modules/nativeSettingsHandler/test/testNativeSettingsHandler.js
@@ -17,8 +17,6 @@ var fluid = require("gpii-universal");
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
-fluid.require("%gpii-windows");
-
 require("../src/nativeSettingsHandler");
 
 fluid.registerNamespace("gpii.tests.windows.nativeSettingsHandler");

--- a/gpii/node_modules/systemSettingsHandler/test/testSystemSettingsHandler.js
+++ b/gpii/node_modules/systemSettingsHandler/test/testSystemSettingsHandler.js
@@ -21,8 +21,6 @@ var fluid = require("gpii-universal");
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 
-fluid.require("%gpii-windows");
-
 require("../src/systemSettingsHandler.js");
 
 fluid.registerNamespace("gpii.tests.windows.systemSettingsHandler");

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "evented"
     ],
     "repository": "git://github.com/GPII/windows.git",
-    "main": "./gpii.js",
+    "main": "./index.js",
     "engines": {
         "node": ">=6.3.1"
     }


### PR DESCRIPTION
Improved the error reporting in the language tests.

Also stopped gpii from being started by fixing the main script in `package.json` and removing the `%gpii-windows` requires from the tests (they're harmless, but not needed).