### PR TITLE
NOJIRA: Building the service in its own isolated drive.

### DIFF
--- a/gpii-service/tests/all-tests.js
+++ b/gpii-service/tests/all-tests.js
@@ -19,7 +19,11 @@
 // The service tests are ran in a separate process to the rest of GPII. This not only ensures it's isolated from GPII,
 // but also prevents having to re-build to be ran under electron for the gpii-app tests.
 
-if (!global.fluid) {
+if (process.versions.electron) {
+    // The service code never gets executed in election, so there's no value in testing this.
+    console.log("Skipping gpii-service tests while running in electron");
+    return;
+} else if (!global.fluid) {
     // In child process.
     require("./service-tests.js");
     require("./windows-tests.js");

--- a/provisioning/NpmInstall.ps1
+++ b/provisioning/NpmInstall.ps1
@@ -25,5 +25,10 @@ $csc = Join-Path -Path (Split-Path -Parent $msbuild) csc.exe
 Invoke-Command $csc "/target:exe /out:test-window.exe test-window.cs" $testProcessHandlingDir
 
 # Build the Windows Service
-$serviceDir = Join-Path $rootDir "gpii-service"
-Invoke-Command "npm" "install" $serviceDir
+try
+{
+    subst q: (Join-Path $rootDir "gpii-service")
+    Invoke-Command "npm" "install" q:
+} finally {
+    subst /d q:
+}


### PR DESCRIPTION
This will stop the `gpii-service` build from taking things from `/node_modules`, to using its own `node_modules` instead.