### PR TITLE
GPII-4370: Rejecting settings handler if the settings helper fails.

### DIFF
--- a/gpii/node_modules/systemSettingsHandler/src/systemSettingsHandler.js
+++ b/gpii/node_modules/systemSettingsHandler/src/systemSettingsHandler.js
@@ -136,7 +136,7 @@ windows.systemSettingsHandler.invokeHandler = function (get, payload) {
         } else {
             promise.resolve(results);
         }
-    });
+    }, promise.reject);
 
     return promise;
 };


### PR DESCRIPTION
This stops Morphic from stalling and preventing the logout/shutdown of Windows.

