### PR TITLE
GPII-4470: Storing the currently active window in an environment variable

### DIFF
--- a/gpii/node_modules/gpii-app-zoom/src/appZoom.js
+++ b/gpii/node_modules/gpii-app-zoom/src/appZoom.js
@@ -433,6 +433,8 @@ windows.appZoom.windowActivated = function (that, hwnd) {
                     // Edge's edge case. The window reported by the notification isn't the right window.
                     window.hwnd = windows.user32.GetForegroundWindow();
                 }
+                // Update an environment variable, to share the knowledge with a future child process.
+                process.env.GPII_ACTIVE_WINDOW = window.hwnd;
             }
         }
         if (that.currentWindow) {


### PR DESCRIPTION
This just updates an environment variable, so a new child process knows the active window before the QSS was clicked.

This is so the select to speech app (which will be called by a BYOB) knows what window to read the selected text from.
